### PR TITLE
feat(documents): restore document in trash when same file is uploaded

### DIFF
--- a/apps/papra-server/src/modules/documents/documents.repository.ts
+++ b/apps/papra-server/src/modules/documents/documents.repository.ts
@@ -226,20 +226,25 @@ async function softDeleteDocument({ documentId, organizationId, userId, db, now 
     );
 }
 
-async function restoreDocument({ documentId, organizationId, db }: { documentId: string;organizationId: string; db: Database }) {
-  await db
+async function restoreDocument({ documentId, organizationId, name, userId, db }: { documentId: string;organizationId: string; name?: string; userId?: string; db: Database }) {
+  const [document] = await db
     .update(documentsTable)
     .set({
       isDeleted: false,
       deletedBy: null,
       deletedAt: null,
+      ...(name ? { name, originalName: name } : {}),
+      ...(userId ? { createdBy: userId } : {}),
     })
     .where(
       and(
         eq(documentsTable.id, documentId),
         eq(documentsTable.organizationId, organizationId),
       ),
-    );
+    )
+    .returning();
+
+  return { document };
 }
 
 async function hardDeleteDocument({ documentId, db }: { documentId: string; db: Database }) {

--- a/apps/papra-server/src/modules/documents/documents.usecases.test.ts
+++ b/apps/papra-server/src/modules/documents/documents.usecases.test.ts
@@ -7,6 +7,7 @@ import { collectReadableStreamToString } from '../shared/streams/readable-stream
 import { createSubscriptionsRepository } from '../subscriptions/subscriptions.repository';
 import { createTaggingRulesRepository } from '../tagging-rules/tagging-rules.repository';
 import { createTagsRepository } from '../tags/tags.repository';
+import { documentsTagsTable } from '../tags/tags.table';
 import { createDummyTrackingServices } from '../tracking/tracking.services';
 import { createDocumentAlreadyExistsError } from './documents.errors';
 import { createDocumentsRepository } from './documents.repository';
@@ -75,7 +76,7 @@ describe('documents usecases', () => {
       expect(documentRecords).to.eql([document]);
     });
 
-    test('in the same organization, we should be able to have two documents with the same content, an error is raised if the document already exists', async () => {
+    test('in the same organization, we should not be able to have two documents with the same content, an error is raised if the document already exists', async () => {
       const { db } = await createInMemoryDatabase({
         users: [{ id: 'user-1', email: 'user-1@example.com' }],
         organizations: [{ id: 'organization-1', name: 'Organization 1' }],
@@ -149,6 +150,96 @@ describe('documents usecases', () => {
       await expect(
         documentsStorageService.getFileStream({ storageKey: 'organization-1/originals/doc_2.txt' }),
       ).rejects.toThrow('File not found');
+    });
+
+    test(`if the document already exists but is in the trash
+          - we restore the document
+          - update the existing record, setting the name to the new file name (same content does not mean same name)
+          - pre-existing tags are removed
+          - the tagging rules are applied to the restored document`, async () => {
+      // this is the sha256 hash of 'hello world'
+      const hash = 'b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9';
+
+      // The document is deleted and has the tag-1
+      // A tagging rule that apply tag-2 if the content contains 'hello'
+      // When restoring the document, the tagging rule should apply tag-2
+      const { db } = await createInMemoryDatabase({
+        users: [{ id: 'user-1', email: 'user-1@example.com' }],
+        organizations: [{ id: 'organization-1', name: 'Organization 1' }],
+        organizationMembers: [{ organizationId: 'organization-1', userId: 'user-1', role: ORGANIZATION_ROLES.OWNER }],
+        tags: [
+          { id: 'tag-1', name: 'Tag 1', color: '#000000', organizationId: 'organization-1' },
+          { id: 'tag-2', name: 'Tag 2', color: '#000000', organizationId: 'organization-1' },
+        ],
+        documents: [{
+          id: 'document-1',
+          organizationId: 'organization-1',
+          originalSha256Hash: hash,
+          isDeleted: true,
+          mimeType: 'text/plain',
+          originalStorageKey: 'organization-1/originals/document-1.txt',
+          name: 'file-1.txt',
+          originalName: 'file-1.txt',
+          content: 'hello world',
+        }],
+        documentsTags: [{
+          documentId: 'document-1',
+          tagId: 'tag-1',
+        }],
+        taggingRules: [
+          { id: 'tagging-rule-1', organizationId: 'organization-1', name: 'Tagging Rule 1', enabled: true },
+        ],
+        taggingRuleConditions: [
+          { id: 'tagging-rule-condition-1', taggingRuleId: 'tagging-rule-1', field: 'content', operator: 'contains', value: 'hello' },
+        ],
+        taggingRuleActions: [
+          { id: 'tagging-rule-action-1', taggingRuleId: 'tagging-rule-1', tagId: 'tag-2' },
+        ],
+      });
+
+      const documentsRepository = createDocumentsRepository({ db });
+      const documentsStorageService = await createDocumentStorageService({ config: { documentsStorage: { driver: 'in-memory' } } as Config });
+      const plansRepository = createPlansRepository({ config: { organizationPlans: { isFreePlanUnlimited: true } } as Config });
+      const subscriptionsRepository = createSubscriptionsRepository({ db });
+      const trackingServices = createDummyTrackingServices();
+      const taggingRulesRepository = createTaggingRulesRepository({ db });
+      const tagsRepository = createTagsRepository({ db });
+
+      // 3. Re-create the document
+      const { document: documentRestored } = await createDocument({
+        file: new File(['hello world'], 'file-2.txt', { type: 'text/plain' }),
+        organizationId: 'organization-1',
+        documentsRepository,
+        documentsStorageService,
+        plansRepository,
+        subscriptionsRepository,
+        trackingServices,
+        taggingRulesRepository,
+        tagsRepository,
+      });
+
+      expect(documentRestored).to.deep.include({
+        id: 'document-1',
+        organizationId: 'organization-1',
+        name: 'file-2.txt',
+        originalName: 'file-2.txt',
+        isDeleted: false,
+        deletedBy: null,
+        deletedAt: null,
+      });
+
+      const documentsRecordsAfterRestoration = await db.select().from(documentsTable);
+
+      expect(documentsRecordsAfterRestoration.length).to.eql(1);
+
+      expect(documentsRecordsAfterRestoration[0]).to.eql(documentRestored);
+
+      const documentsTagsRecordsAfterRestoration = await db.select().from(documentsTagsTable);
+
+      expect(documentsTagsRecordsAfterRestoration).to.eql([{
+        documentId: 'document-1',
+        tagId: 'tag-2',
+      }]);
     });
 
     test('when there is an issue when inserting the document in the db, the file should not be saved in the storage', async () => {

--- a/apps/papra-server/src/modules/tags/tags.repository.ts
+++ b/apps/papra-server/src/modules/tags/tags.repository.ts
@@ -19,6 +19,7 @@ export function createTagsRepository({ db }: { db: Database }) {
       addTagToDocument,
       addTagsToDocument,
       removeTagFromDocument,
+      removeAllTagsFromDocument,
     },
     { db },
   );
@@ -91,4 +92,8 @@ async function removeTagFromDocument({ tagId, documentId, db }: { tagId: string;
       eq(documentsTagsTable.documentId, documentId),
     ),
   );
+}
+
+async function removeAllTagsFromDocument({ documentId, db }: { documentId: string; db: Database }) {
+  await db.delete(documentsTagsTable).where(eq(documentsTagsTable.documentId, documentId));
 }


### PR DESCRIPTION
If the document already exists but is in the trash :
 - we restore the document
 - update the existing record, setting the name to the new file (same content does not mean same name)
 - pre-existing tags are removed
 - the tagging rules are applied to the restored document

Closes #142