### PR TITLE
fix(documents): fix padding when tags input wraps

### DIFF
--- a/apps/papra-client/src/modules/tags/components/tag-picker.component.tsx
+++ b/apps/papra-client/src/modules/tags/components/tag-picker.component.tsx
@@ -55,7 +55,7 @@ export const DocumentTagPicker: Component<{
               <TagComponent name={tag.name} color={tag.color} class="text-xs my-1" closable onClose={() => state.remove(tag)} />
             )}
           </For>
-          <ComboboxInput />
+          <ComboboxInput class="pb-2" />
 
         </span>
 

--- a/apps/papra-client/src/modules/tags/components/tag-picker.component.tsx
+++ b/apps/papra-client/src/modules/tags/components/tag-picker.component.tsx
@@ -55,7 +55,7 @@ export const DocumentTagPicker: Component<{
               <TagComponent name={tag.name} color={tag.color} class="text-xs my-1" closable onClose={() => state.remove(tag)} />
             )}
           </For>
-          <ComboboxInput class="pb-2" />
+          <ComboboxInput class="py-2" />
 
         </span>
 


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/2563d25e-2f52-420e-a3be-2ee2a835c27d)
After:
![image](https://github.com/user-attachments/assets/233bdd5b-a318-4037-a656-cf53e79ef297)
