### PR TITLE
refactor(theme): unify light and dark theme colors

### DIFF
--- a/apps/papra-client/src/app.css
+++ b/apps/papra-client/src/app.css
@@ -8,8 +8,9 @@
   --popover: 0 0% 100%;
   --popover-foreground: 0 0% 3.9%;
 
-  --primary: 16 99% 65%;
+  --primary: 77 80% 65%;
   --primary-foreground: 0 0% 3.9%;
+  --primary-icons: 77 70% 50%;
 
   --secondary: 0 0% 96.1%;
   --secondary-foreground: 0 0% 9%;
@@ -17,7 +18,7 @@
   --muted: 0 0% 96.1%;
   --muted-foreground: 0 0% 45.1%;
 
-  --accent: 0 0% 96.1%;
+  --accent: 0 0% 95%;
   --accent-foreground: 0 0% 9%;
 
   --destructive: 0 84.2% 60.2%;
@@ -45,6 +46,7 @@
 
   --primary: 77 100% 74%;
   --primary-foreground: 0 0% 9%;
+  --primary-icons: 77 100% 74%;
 
   --secondary: 0 0% 14.9%;
   --secondary-foreground: 0 0% 98%;

--- a/apps/papra-client/src/modules/documents/components/documents-list.component.tsx
+++ b/apps/papra-client/src/modules/documents/components/documents-list.component.tsx
@@ -75,7 +75,7 @@ export const DocumentsPaginatedList: Component<{
         cell: data => (
           <div class="overflow-hidden flex gap-4 items-center">
             <div class="bg-muted flex items-center justify-center p-2 rounded-lg">
-              <div class={cn(getDocumentIcon({ document: data.row.original }), 'size-6 text-primary')}></div>
+              <div class={cn(getDocumentIcon({ document: data.row.original }), 'size-6 text-primary-icons')}></div>
             </div>
 
             <div class="flex-1 flex flex-col gap-1 truncate">

--- a/apps/papra-client/uno.config.ts
+++ b/apps/papra-client/uno.config.ts
@@ -46,6 +46,7 @@ export default defineConfig({
       primary: {
         DEFAULT: 'hsl(var(--primary))',
         foreground: 'hsl(var(--primary-foreground))',
+        icons: 'hsl(var(--primary-icons))',
       },
       secondary: {
         DEFAULT: 'hsl(var(--secondary))',


### PR DESCRIPTION
Uses the same color as light theme, except icons can have a separate color with slightly more contrast.

![Image](https://github.com/user-attachments/assets/aa84f5f2-86b7-46c9-8a39-a11cb3b8343f)

Closes #75 