### PR TITLE
fix(auth): fix deprecated better-auth database id generation conf

### DIFF
--- a/apps/papra-server/src/modules/app/auth/auth.services.ts
+++ b/apps/papra-server/src/modules/app/auth/auth.services.ts
@@ -84,7 +84,7 @@ export function getAuth({
 
     advanced: {
       // Drizzle tables handle the id generation
-      generateId: false,
+      database: { generateId: false },
     },
     socialProviders: {
       github: {


### PR DESCRIPTION
Fixing this warning 
> [Better Auth]: Your Better Auth config includes advanced.generateId which is deprecated. Please use advanced.database.generateId instead. This will be removed in future releases.