### PR TITLE
fix: convert uppercase hex codes to lowercase in tag creation/update

### DIFF
--- a/apps/papra-client/src/modules/tags/pages/tags.page.tsx
+++ b/apps/papra-client/src/modules/tags/pages/tags.page.tsx
@@ -119,7 +119,7 @@ export const CreateTagModal: Component<{
   const onSubmit = async ({ name, color, description }: { name: string; color: string; description: string }) => {
     const [,error] = await safely(createTag({
       name,
-      color,
+      color: color.toLowerCase(), 
       description,
       organizationId: props.organizationId,
     }));
@@ -170,7 +170,7 @@ const UpdateTagModal: Component<{
   const onSubmit = async ({ name, color, description }: { name: string; color: string; description: string }) => {
     await updateTag({
       name,
-      color,
+      color: color.toLowerCase(), 
       description,
       organizationId: props.organizationId,
       tagId: props.tag.id,


### PR DESCRIPTION
Fixes 400 error when submitting tags with uppercase hex colour codes.

Bug Fix 
https://github.com/papra-hq/papra/issues/252
