### PR TITLE
fix(docker): set COREPACK_HOME for rootless image to avoid permission issues

### DIFF
--- a/.changeset/floppy-tires-eat.md
+++ b/.changeset/floppy-tires-eat.md
@@ -1,0 +1,5 @@
+---
+"@papra/app-server": patch
+---
+
+Fix permission issue for non 1000:1000 rootless user

--- a/docker/Dockerfile.rootless
+++ b/docker/Dockerfile.rootless
@@ -2,6 +2,8 @@
 FROM node:22-slim AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
+# Set corepack home to nonroot user home to avoid permission issues
+ENV COREPACK_HOME=/home/nonroot/.corepack
 RUN npm install -g corepack@latest
 RUN corepack enable
 RUN corepack prepare pnpm@10.12.3 --activate


### PR DESCRIPTION
Close #349