### PR TITLE
fix(documents): corrected weird centering for long file names

### DIFF
--- a/.changeset/blue-ghosts-glow.md
+++ b/.changeset/blue-ghosts-glow.md
@@ -1,0 +1,5 @@
+---
+"@papra/app-client": patch
+---
+
+Fix weird centering in document page for long filenames

--- a/apps/papra-client/src/modules/documents/pages/document.page.tsx
+++ b/apps/papra-client/src/modules/documents/pages/document.page.tsx
@@ -41,7 +41,7 @@ const KeyValues: Component<{ data?: KeyValueItem[] }> = (props) => {
         <For each={props.data}>
           {item => (
             <tr>
-              <td class="py-1 pr-2 text-sm text-muted-foreground flex items-center gap-2">
+              <td class="py-1 pr-2 text-sm text-muted-foreground flex items-center gap-2 whitespace-nowrap">
                 {item.icon && <div class={item.icon}></div>}
                 {item.label}
               </td>
@@ -232,18 +232,18 @@ export const DocumentPage: Component = () => {
                 <div class="flex-1">
                   <Button
                     variant="ghost"
-                    class="flex items-center gap-2 group bg-transparent! px-0"
+                    class="flex items-center gap-2 group bg-transparent! px-0 text-left h-auto"
                     onClick={() => openRenameDialog({
                       documentId: getDocument().id,
                       organizationId: params.organizationId,
                       documentName: getDocument().name,
                     })}
                   >
-                    <h1 class="text-xl font-semibold">
+                    <h1 class="text-xl font-semibold lh-tight" title={getDocument().name}>
                       {getDocument().name}
                     </h1>
 
-                    <div class="i-tabler-pencil size-4 text-muted-foreground group-hover:text-foreground transition-colors"></div>
+                    <div class="i-tabler-pencil size-4 text-muted-foreground group-hover:text-foreground transition-colors flex-shrink-0"></div>
                   </Button>
                   <p class="text-sm text-muted-foreground mb-6">{getDocument().id}</p>
 
@@ -354,7 +354,7 @@ export const DocumentPage: Component = () => {
                           value: (
                             <Button
                               variant="ghost"
-                              class="flex items-center gap-2 group bg-transparent! p-0 h-auto"
+                              class="flex items-center gap-2 group bg-transparent! p-0 h-auto text-left"
                               onClick={() => openRenameDialog({
                                 documentId: getDocument().id,
                                 organizationId: params.organizationId,
@@ -363,7 +363,7 @@ export const DocumentPage: Component = () => {
                             >
                               {getDocument().name}
 
-                              <div class="i-tabler-pencil size-4 text-muted-foreground group-hover:text-foreground transition-colors"></div>
+                              <div class="i-tabler-pencil size-4 text-muted-foreground group-hover:text-foreground transition-colors flex-shrink-0"></div>
                             </Button>
                           ),
                           icon: 'i-tabler-file-text',


### PR DESCRIPTION
Closes #360 

Before:
![screenshot-2025-07-01-23-57-06](https://github.com/user-attachments/assets/bc3aa90e-48bf-44ac-87c4-a79d71d2ee89)


After:
![screenshot-2025-07-01-23-57-15](https://github.com/user-attachments/assets/decdc448-2c98-4ede-9fa2-2d297270d415)
