### PR TITLE
feat: add run now button for tagging rules

### DIFF
--- a/.changeset/smooth-adults-occur.md
+++ b/.changeset/smooth-adults-occur.md
@@ -1,0 +1,5 @@
+---
+"@papra/docker": patch
+---
+
+Added button to reapply a tagging rule

--- a/apps/docs/src/content/docs/03-guides/06-tagging-rules.mdx
+++ b/apps/docs/src/content/docs/03-guides/06-tagging-rules.mdx
@@ -1,0 +1,102 @@
+---
+title: Using Tagging Rules
+description: Learn how to automate document organization with tagging rules.
+slug: guides/tagging-rules
+---
+
+## What are Tagging Rules?
+
+Tagging rules allow you to automatically apply tags to documents based on specific conditions. This helps maintain consistent organization without manual effort, especially when dealing with large numbers of documents.
+
+## How Tagging Rules Work
+
+When a tagging rule is enabled, it automatically checks new documents as they're uploaded. If a document matches the rule's conditions, the specified tags are automatically applied.
+
+### Rule Components
+
+Each tagging rule consists of:
+
+1. **Conditions**: Rules that determine which documents should be tagged
+   - Field: The document property to check (e.g., name, content)
+   - Operator: How to compare the field (e.g., contains, equals)
+   - Value: The text to match against
+
+2. **Actions**: The tags to apply when conditions are met
+
+## Applying Rules to Existing Documents
+
+### The "Run Now" Feature
+
+When you create a new tagging rule, it only applies to documents uploaded *after* the rule is created. To apply the rule to documents that already exist in your organization, use the **"Apply to existing documents"** button.
+
+This feature is particularly useful when:
+- You create a new rule and want to organize your existing documents
+- You modify a rule and want to reprocess documents
+- You're setting up your organization and want to retroactively organize imported documents
+
+### How to Apply a Rule to Existing Documents
+
+1. Navigate to your organization's Tagging Rules page
+2. Find the rule you want to apply
+3. Click the **"Apply to existing documents"** button
+4. Confirm the action in the dialog
+5. The task is queued and will be processed in the background
+
+The system will:
+- Queue a background task to process all documents
+- Process documents in batches to avoid overloading the system
+- Check all existing documents in your organization
+- Apply tags where the rule's conditions match
+- Show you a success message once the task is queued
+
+:::tip
+Applying a rule to existing documents runs as a background task, so you don't need to wait for it to complete. The processing happens asynchronously and efficiently handles large document collections by processing them in batches.
+:::
+
+## Best Practices
+
+### Creating Effective Rules
+
+1. **Be specific**: Use precise conditions to avoid over-tagging
+2. **Test first**: Create a rule and test it on a few documents before applying to all existing documents
+3. **Use multiple conditions**: Combine conditions for more accurate matching
+4. **Review regularly**: Periodically review your rules to ensure they're still relevant
+
+### Example Rules
+
+**Invoice Classification**
+- Condition: Document name contains "invoice"
+- Action: Apply "Invoice" tag
+
+**Quarterly Reports**
+- Condition: Document name contains "Q1" or "Q2" or "Q3" or "Q4"
+- Action: Apply "Report" tag
+
+## Using the API
+
+You can also apply tagging rules programmatically using the API. The endpoint enqueues a background task and returns immediately:
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  https://api.papra.app/api/organizations/YOUR_ORG_ID/tagging-rules/RULE_ID/apply
+```
+
+Response (HTTP 202 Accepted):
+```json
+{
+  "taskId": "task_abc123"
+}
+```
+
+Where:
+- `taskId`: The ID of the background task processing your request
+
+:::note
+The API returns a task ID immediately. The actual processing happens in the background and may take some time depending on the number of documents. Task status retrieval will be available in a future release.
+:::
+
+## Related Resources
+
+- [API Endpoints Documentation](/resources/api-endpoints)
+- [CLI Documentation](/resources/cli)

--- a/apps/docs/src/content/docs/04-resources/03-api-endpoints.mdx
+++ b/apps/docs/src/content/docs/04-resources/03-api-endpoints.mdx
@@ -307,3 +307,13 @@ Remove a tag from a document.
 
 - Required API key permissions: `tags:read` and `documents:update`
 - Response: empty (204 status code)
+
+### Apply tagging rule to existing documents
+
+**POST** `/api/organizations/:organizationId/tagging-rules/:taggingRuleId/apply`
+
+Enqueue a background task to apply a tagging rule to all existing documents in the organization. This endpoint returns immediately with a task ID, and the processing happens asynchronously in the background. The task will check all documents and apply tags where the rule's conditions match.
+
+- Required API key permissions: `tags:read` and `documents:update`
+- Response (JSON, HTTP 202)
+  - `taskId`: The ID of the background task. You can use this to track the task's progress (task status retrieval coming in a future release).

--- a/apps/docs/src/content/navigation.ts
+++ b/apps/docs/src/content/navigation.ts
@@ -40,6 +40,10 @@ export const sidebar = [
         label: 'Document Encryption',
         slug: 'guides/document-encryption',
       },
+      {
+        label: 'Tagging Rules',
+        slug: 'guides/tagging-rules',
+      },
     ],
   },
   {

--- a/apps/papra-client/src/locales/de.dictionary.ts
+++ b/apps/papra-client/src/locales/de.dictionary.ts
@@ -400,9 +400,16 @@ export const translations: Partial<TranslationsDictionary> = {
   'tagging-rules.form.tags.add-tag': 'Tag erstellen',
   'tagging-rules.form.submit': 'Regel erstellen',
   'tagging-rules.update.title': 'Tagging-Regel aktualisieren',
-  'tagging-rules.update.error': 'Tagging-Regel konnte nicht aktualisiert werden',
+  'tagging-rules.update.error': 'Fehler beim Aktualisieren der Tagging-Regel',
   'tagging-rules.update.submit': 'Regel aktualisieren',
   'tagging-rules.update.cancel': 'Abbrechen',
+  'tagging-rules.apply.button': 'Auf vorhandene Dokumente anwenden',
+  'tagging-rules.apply.confirm.title': 'Regel auf vorhandene Dokumente anwenden?',
+  'tagging-rules.apply.confirm.description': 'Dies überprüft alle vorhandenen Dokumente in Ihrer Organisation und wendet Tags an, wo Bedingungen übereinstimmen. Die Verarbeitung erfolgt im Hintergrund.',
+  'tagging-rules.apply.confirm.button': 'Regel anwenden',
+  'tagging-rules.apply.success': 'Regelanwendung im Hintergrund gestartet',
+  'tagging-rules.apply.error': 'Fehler beim Starten der Regelanwendung',
+  'tagging-rules.apply.processing': 'Wird gestartet...',
 
   // Intake emails
 

--- a/apps/papra-client/src/locales/en.dictionary.ts
+++ b/apps/papra-client/src/locales/en.dictionary.ts
@@ -401,6 +401,13 @@ export const translations = {
   'tagging-rules.update.error': 'Failed to update tagging rule',
   'tagging-rules.update.submit': 'Update rule',
   'tagging-rules.update.cancel': 'Cancel',
+  'tagging-rules.apply.button': 'Apply to existing documents',
+  'tagging-rules.apply.confirm.title': 'Apply rule to existing documents?',
+  'tagging-rules.apply.confirm.description': 'This will check all existing documents in your organization and apply tags where conditions match. The processing will happen in the background.',
+  'tagging-rules.apply.confirm.button': 'Apply rule',
+  'tagging-rules.apply.success': 'Rule application started in the background',
+  'tagging-rules.apply.error': 'Failed to start rule application',
+  'tagging-rules.apply.processing': 'Starting...',
 
   // Intake emails
 

--- a/apps/papra-client/src/modules/tagging-rules/pages/tagging-rules.page.tsx
+++ b/apps/papra-client/src/modules/tagging-rules/pages/tagging-rules.page.tsx
@@ -109,6 +109,7 @@ const TaggingRuleCard: Component<{ taggingRule: TaggingRule }> = (props) => {
           variant="outline"
           size="icon"
           aria-label={t('tagging-rules.list.card.edit')}
+          class="size-8"
         >
           <div class="i-tabler-edit size-4" />
         </Button>
@@ -119,6 +120,7 @@ const TaggingRuleCard: Component<{ taggingRule: TaggingRule }> = (props) => {
           onClick={() => deleteTaggingRuleMutation.mutate()}
           disabled={deleteTaggingRuleMutation.isPending}
           aria-label={t('tagging-rules.list.card.delete')}
+          class="size-8"
         >
           <div class="i-tabler-trash size-4" />
         </Button>

--- a/apps/papra-client/src/modules/tagging-rules/tagging-rules.services.ts
+++ b/apps/papra-client/src/modules/tagging-rules/tagging-rules.services.ts
@@ -43,3 +43,18 @@ export async function updateTaggingRule({ organizationId, taggingRuleId, tagging
     body: taggingRule,
   });
 }
+
+export async function applyTaggingRuleToExistingDocuments({
+  organizationId,
+  taggingRuleId,
+}: {
+  organizationId: string;
+  taggingRuleId: string;
+}) {
+  const result = await apiClient<{ taskId: string }>({
+    path: `/api/organizations/${organizationId}/tagging-rules/${taggingRuleId}/apply`,
+    method: 'POST',
+  });
+
+  return result;
+}

--- a/apps/papra-server/src/modules/documents/documents.repository.ts
+++ b/apps/papra-server/src/modules/documents/documents.repository.ts
@@ -36,6 +36,7 @@ export function createDocumentsRepository({ db }: { db: Database }) {
       getAllOrganizationDocuments,
       getOrganizationDocumentsQuery,
       getAllOrganizationDocumentsIterator,
+      getAllOrganizationUndeletedDocumentsIterator,
       updateDocument,
     },
     { db },
@@ -400,9 +401,34 @@ function getOrganizationDocumentsQuery({ organizationId, db }: { organizationId:
   );
 }
 
-function getAllOrganizationDocumentsIterator({ organizationId, db, batchSize = 100 }: { organizationId: string; db: Database; batchSize?: number }) {
-  const query = getOrganizationDocumentsQuery({ organizationId, db }).$dynamic();
+function getAllOrganizationDocumentsIterator({ organizationId, batchSize = 100, db }: { organizationId: string; batchSize?: number; db: Database }) {
+  const query = db
+    .select({
+      id: documentsTable.id,
+      originalStorageKey: documentsTable.originalStorageKey,
+    })
+    .from(documentsTable)
+    .where(
+      eq(documentsTable.organizationId, organizationId),
+    )
+    .orderBy(documentsTable.createdAt);
+
   return createIterator({ query, batchSize }) as AsyncGenerator<{ id: string; originalStorageKey: string }>;
+}
+
+function getAllOrganizationUndeletedDocumentsIterator({ organizationId, batchSize = 100, db }: { organizationId: string; batchSize?: number; db: Database }) {
+  const query = db
+    .select()
+    .from(documentsTable)
+    .where(
+      and(
+        eq(documentsTable.organizationId, organizationId),
+        eq(documentsTable.isDeleted, false),
+      ),
+    )
+    .orderBy(documentsTable.createdAt);
+
+  return createIterator({ query, batchSize });
 }
 
 async function updateDocument({ documentId, organizationId, name, content, db }: { documentId: string; organizationId: string; name?: string; content?: string; db: Database }) {

--- a/apps/papra-server/src/modules/documents/documents.repository.ts
+++ b/apps/papra-server/src/modules/documents/documents.repository.ts
@@ -34,7 +34,6 @@ export function createDocumentsRepository({ db }: { db: Database }) {
       getOrganizationDocumentBySha256Hash,
       getAllOrganizationTrashDocuments,
       getAllOrganizationDocuments,
-      getOrganizationDocumentsQuery,
       getAllOrganizationDocumentsIterator,
       getAllOrganizationUndeletedDocumentsIterator,
       updateDocument,
@@ -392,15 +391,6 @@ async function getAllOrganizationDocuments({ organizationId, db }: { organizatio
   };
 }
 
-function getOrganizationDocumentsQuery({ organizationId, db }: { organizationId: string; db: Database }) {
-  return db.select({
-    id: documentsTable.id,
-    originalStorageKey: documentsTable.originalStorageKey,
-  }).from(documentsTable).where(
-    eq(documentsTable.organizationId, organizationId),
-  );
-}
-
 function getAllOrganizationDocumentsIterator({ organizationId, batchSize = 100, db }: { organizationId: string; batchSize?: number; db: Database }) {
   const query = db
     .select({
@@ -411,7 +401,8 @@ function getAllOrganizationDocumentsIterator({ organizationId, batchSize = 100, 
     .where(
       eq(documentsTable.organizationId, organizationId),
     )
-    .orderBy(documentsTable.createdAt);
+    .orderBy(documentsTable.createdAt)
+    .$dynamic();
 
   return createIterator({ query, batchSize }) as AsyncGenerator<{ id: string; originalStorageKey: string }>;
 }
@@ -426,7 +417,8 @@ function getAllOrganizationUndeletedDocumentsIterator({ organizationId, batchSiz
         eq(documentsTable.isDeleted, false),
       ),
     )
-    .orderBy(documentsTable.createdAt);
+    .orderBy(documentsTable.createdAt)
+    .$dynamic();
 
   return createIterator({ query, batchSize });
 }

--- a/apps/papra-server/src/modules/tagging-rules/tagging-rules.usecases.test.ts
+++ b/apps/papra-server/src/modules/tagging-rules/tagging-rules.usecases.test.ts
@@ -2,6 +2,7 @@ import { eq } from 'drizzle-orm';
 import { describe, expect, test } from 'vitest';
 import { createInMemoryDatabase } from '../app/database/database.test-utils';
 import { createDocumentActivityRepository } from '../documents/document-activity/document-activity.repository';
+import { createDocumentsRepository } from '../documents/documents.repository';
 import { documentsTable } from '../documents/documents.table';
 import { createTestLogger } from '../shared/logger/logger.test-utils';
 import { isNil } from '../shared/utils';
@@ -9,7 +10,7 @@ import { createTagsRepository } from '../tags/tags.repository';
 import { documentsTagsTable } from '../tags/tags.table';
 import { createWebhookRepository } from '../webhooks/webhook.repository';
 import { createTaggingRulesRepository } from './tagging-rules.repository';
-import { applyTaggingRules } from './tagging-rules.usecases';
+import { applyTaggingRules, applyTaggingRuleToExistingDocuments } from './tagging-rules.usecases';
 
 describe('tagging-rules usecases', () => {
   describe('applyTaggingRules', () => {
@@ -110,6 +111,105 @@ describe('tagging-rules usecases', () => {
       const documentTags = await db.select().from(documentsTagsTable);
 
       expect(documentTags).to.eql([]);
+    });
+  });
+
+  describe('applyTaggingRuleToExistingDocuments', () => {
+    test('applying rule to existing documents tags only matching ones', async () => {
+      const { db } = await createInMemoryDatabase({
+        organizations: [{ id: 'org_1', name: 'Org 1' }],
+        tags: [{ id: 'tag_1', name: 'Invoice', color: '#000000', organizationId: 'org_1' }],
+        documents: [
+          { id: 'doc_1', organizationId: 'org_1', name: 'Invoice 2024', originalName: 'Invoice 2024', originalStorageKey: 'doc_1', originalSha256Hash: 'hash_1', mimeType: 'text/plain' },
+          { id: 'doc_2', organizationId: 'org_1', name: 'Invoice Q1', originalName: 'Invoice Q1', originalStorageKey: 'doc_2', originalSha256Hash: 'hash_2', mimeType: 'text/plain' },
+          { id: 'doc_3', organizationId: 'org_1', name: 'Contract', originalName: 'Contract', originalStorageKey: 'doc_3', originalSha256Hash: 'hash_3', mimeType: 'text/plain' },
+        ],
+        taggingRules: [{ id: 'tr_1', organizationId: 'org_1', name: 'Tag Invoices', enabled: true }],
+        taggingRuleConditions: [{ id: 'trc_1', taggingRuleId: 'tr_1', field: 'name', operator: 'contains', value: 'Invoice' }],
+        taggingRuleActions: [{ id: 'tra_1', taggingRuleId: 'tr_1', tagId: 'tag_1' }],
+      });
+
+      const taggingRulesRepository = createTaggingRulesRepository({ db });
+      const documentsRepository = createDocumentsRepository({ db });
+      const tagsRepository = createTagsRepository({ db });
+      const webhookRepository = createWebhookRepository({ db });
+      const documentActivityRepository = createDocumentActivityRepository({ db });
+
+      const result = await applyTaggingRuleToExistingDocuments({
+        taggingRuleId: 'tr_1',
+        organizationId: 'org_1',
+        taggingRulesRepository,
+        documentsRepository,
+        tagsRepository,
+        webhookRepository,
+        documentActivityRepository,
+      });
+
+      expect(result.processedCount).toBe(3);
+      expect(result.taggedCount).toBe(3); // All documents are processed (applyTaggingRules is called for each)
+
+      const documentTags = await db.select().from(documentsTagsTable);
+
+      // Only doc_1 and doc_2 should be tagged (they contain "Invoice")
+      expect(documentTags).toHaveLength(2);
+      expect(documentTags.map(dt => dt.documentId).sort()).toEqual(['doc_1', 'doc_2']);
+      expect(documentTags.every(dt => dt.tagId === 'tag_1')).toBe(true);
+    });
+
+    test('returns error when tagging rule does not exist', async () => {
+      const { db } = await createInMemoryDatabase({
+        organizations: [{ id: 'org_1', name: 'Org 1' }],
+      });
+
+      const taggingRulesRepository = createTaggingRulesRepository({ db });
+      const documentsRepository = createDocumentsRepository({ db });
+      const tagsRepository = createTagsRepository({ db });
+      const webhookRepository = createWebhookRepository({ db });
+      const documentActivityRepository = createDocumentActivityRepository({ db });
+
+      await expect(
+        applyTaggingRuleToExistingDocuments({
+          taggingRuleId: 'non_existent',
+          organizationId: 'org_1',
+          taggingRulesRepository,
+          documentsRepository,
+          tagsRepository,
+          webhookRepository,
+          documentActivityRepository,
+        }),
+      ).rejects.toThrow('Tagging rule not found');
+    });
+
+    test('processes all documents even when there are no tagging rules enabled', async () => {
+      const { db } = await createInMemoryDatabase({
+        organizations: [{ id: 'org_1', name: 'Org 1' }],
+        documents: [
+          { id: 'doc_1', organizationId: 'org_1', name: 'Doc 1', originalName: 'Doc 1', originalStorageKey: 'doc_1', originalSha256Hash: 'hash_1', mimeType: 'text/plain' },
+        ],
+        taggingRules: [{ id: 'tr_1', organizationId: 'org_1', name: 'Rule 1', enabled: false }],
+      });
+
+      const taggingRulesRepository = createTaggingRulesRepository({ db });
+      const documentsRepository = createDocumentsRepository({ db });
+      const tagsRepository = createTagsRepository({ db });
+      const webhookRepository = createWebhookRepository({ db });
+      const documentActivityRepository = createDocumentActivityRepository({ db });
+
+      const result = await applyTaggingRuleToExistingDocuments({
+        taggingRuleId: 'tr_1',
+        organizationId: 'org_1',
+        taggingRulesRepository,
+        documentsRepository,
+        tagsRepository,
+        webhookRepository,
+        documentActivityRepository,
+      });
+
+      expect(result.processedCount).toBe(1);
+      expect(result.taggedCount).toBe(1);
+
+      const documentTags = await db.select().from(documentsTagsTable);
+      expect(documentTags).toHaveLength(0); // No tags applied because rule is disabled
     });
   });
 });

--- a/apps/papra-server/src/modules/tagging-rules/tagging-rules.usecases.test.ts
+++ b/apps/papra-server/src/modules/tagging-rules/tagging-rules.usecases.test.ts
@@ -48,13 +48,22 @@ describe('tagging-rules usecases', () => {
       expect(getLogs({ excludeTimestampMs: true })).to.eql([
         {
           data: {
-            tagIdsToApply: ['tag_1'],
+            taggingRuleId: 'tr_1',
             appliedTagIds: ['tag_1'],
-            taggingRulesIdsToApply: ['tr_1'],
+            expectedTagCount: 1,
             hasAllTagBeenApplied: true,
           },
           level: 'info',
-          message: 'Tagging rules applied',
+          message: 'Tagging rule applied to document',
+          namespace: 'test',
+        },
+        {
+          data: {
+            taggingRulesCount: 1,
+            appliedTagIds: ['tag_1'],
+          },
+          level: 'info',
+          message: 'All tagging rules applied to document',
           namespace: 'test',
         },
       ]);
@@ -146,7 +155,7 @@ describe('tagging-rules usecases', () => {
       });
 
       expect(result.processedCount).toBe(3);
-      expect(result.taggedCount).toBe(3); // All documents are processed (applyTaggingRules is called for each)
+      expect(result.taggedDocumentsCount).toBe(2); // All documents are processed (applyTaggingRules is called for each)
 
       const documentTags = await db.select().from(documentsTagsTable);
 
@@ -180,7 +189,7 @@ describe('tagging-rules usecases', () => {
       ).rejects.toThrow('Tagging rule not found');
     });
 
-    test('processes all documents even when there are no tagging rules enabled', async () => {
+    test('processes all documents even when the tagging rule is disabled', async () => {
       const { db } = await createInMemoryDatabase({
         organizations: [{ id: 'org_1', name: 'Org 1' }],
         documents: [
@@ -206,7 +215,7 @@ describe('tagging-rules usecases', () => {
       });
 
       expect(result.processedCount).toBe(1);
-      expect(result.taggedCount).toBe(1);
+      expect(result.taggedDocumentsCount).toBe(0); // No documents tagged because rule is disabled
 
       const documentTags = await db.select().from(documentsTagsTable);
       expect(documentTags).toHaveLength(0); // No tags applied because rule is disabled

--- a/apps/papra-server/src/modules/tagging-rules/tasks/apply-tagging-rule-to-documents.task.ts
+++ b/apps/papra-server/src/modules/tagging-rules/tasks/apply-tagging-rule-to-documents.task.ts
@@ -1,0 +1,46 @@
+import type { Database } from '../../app/database/database.types';
+import type { TaskServices } from '../../tasks/tasks.services';
+import { createDocumentActivityRepository } from '../../documents/document-activity/document-activity.repository';
+import { createDocumentsRepository } from '../../documents/documents.repository';
+import { createLogger } from '../../shared/logger/logger';
+import { createTagsRepository } from '../../tags/tags.repository';
+import { createWebhookRepository } from '../../webhooks/webhook.repository';
+import { createTaggingRulesRepository } from '../tagging-rules.repository';
+import { applyTaggingRuleToExistingDocuments } from '../tagging-rules.usecases';
+
+const logger = createLogger({ namespace: 'tasks:apply-tagging-rule' });
+
+export async function registerApplyTaggingRuleToDocumentsTask({ taskServices, db }: { taskServices: TaskServices; db: Database }) {
+  const taskName = 'apply-tagging-rule-to-documents';
+
+  taskServices.registerTask({
+    taskName,
+    handler: async ({ data }) => {
+      const documentsRepository = createDocumentsRepository({ db });
+      const taggingRulesRepository = createTaggingRulesRepository({ db });
+      const tagsRepository = createTagsRepository({ db });
+      const webhookRepository = createWebhookRepository({ db });
+      const documentActivityRepository = createDocumentActivityRepository({ db });
+
+      // TODO: remove type cast once taskServices has proper typing
+      const { organizationId, taggingRuleId } = data as { organizationId: string; taggingRuleId: string };
+
+      logger.info({ organizationId, taggingRuleId }, 'Starting background task to apply tagging rule');
+
+      const result = await applyTaggingRuleToExistingDocuments({
+        taggingRuleId,
+        organizationId,
+        taggingRulesRepository,
+        documentsRepository,
+        tagsRepository,
+        webhookRepository,
+        documentActivityRepository,
+        logger,
+      });
+
+      logger.info({ organizationId, taggingRuleId, result }, 'Completed background task to apply tagging rule');
+
+      return result;
+    },
+  });
+}

--- a/apps/papra-server/src/modules/tasks/tasks.definitions.ts
+++ b/apps/papra-server/src/modules/tasks/tasks.definitions.ts
@@ -6,10 +6,12 @@ import { registerExtractDocumentFileContentTask } from '../documents/tasks/extra
 import { registerHardDeleteExpiredDocumentsTask } from '../documents/tasks/hard-delete-expired-documents.task';
 import { registerExpireInvitationsTask } from '../organizations/tasks/expire-invitations.task';
 import { registerPurgeExpiredOrganizationsTask } from '../organizations/tasks/purge-expired-organizations.task';
+import { registerApplyTaggingRuleToDocumentsTask } from '../tagging-rules/tasks/apply-tagging-rule-to-documents.task';
 
 export async function registerTaskDefinitions({ taskServices, db, config, documentsStorageService }: { taskServices: TaskServices; db: Database; config: Config; documentsStorageService: DocumentStorageService }) {
   await registerHardDeleteExpiredDocumentsTask({ taskServices, db, config, documentsStorageService });
   await registerExpireInvitationsTask({ taskServices, db, config });
   await registerPurgeExpiredOrganizationsTask({ taskServices, db, config, documentsStorageService });
   await registerExtractDocumentFileContentTask({ taskServices, db, documentsStorageService });
+  await registerApplyTaggingRuleToDocumentsTask({ taskServices, db });
 }


### PR DESCRIPTION
Allow users to apply existing tagging rules to all documents in their organization. This helps when rules are created after documents have already been imported.

Fixes #251