### PR TITLE
fix: Fix typo in English dictionary for demo popup description

### DIFF
--- a/apps/papra-client/src/locales/en.dictionary.ts
+++ b/apps/papra-client/src/locales/en.dictionary.ts
@@ -642,7 +642,7 @@ export const translations = {
 
   // Demo
 
-  'demo.popup.description': 'This is a demo environment, all data is save to your browser local storage.',
+  'demo.popup.description': 'This is a demo environment, all data is saved to your browser local storage.',
   'demo.popup.discord': 'Join the {{ discordLink }} to get support, propose features or just chat.',
   'demo.popup.discord-link-label': 'Discord server',
   'demo.popup.reset': 'Reset demo data',


### PR DESCRIPTION
This PR fixes a typo I happened to see whilst creating the Dutch translation.