### PR TITLE
feat: Sort tags alphabetically

### DIFF
--- a/apps/papra-server/src/modules/tags/tags.repository.test.ts
+++ b/apps/papra-server/src/modules/tags/tags.repository.test.ts
@@ -123,6 +123,9 @@ describe('tags repository', () => {
 
       const { tags } = await tagsRepository.getOrganizationTags({ organizationId: 'organization-1' });
 
+      // NOTE: I think this should take into account the new default sorting order for tags?
+      // e.g. give Tag `tag-1` a name that alphabetically comes AFTER Tag `tag-2`, and expect here that (because `tag-2` is earlier in the `orderBy`) `tag-2` comes as first entry.
+      // this change has not yet been made; waiting on confirmation if this is something Papra wants, or if we're better off with a complete overhaul
       expect(tags).to.eql([
         {
           id: 'tag-1',

--- a/apps/papra-server/src/modules/tags/tags.repository.ts
+++ b/apps/papra-server/src/modules/tags/tags.repository.ts
@@ -38,7 +38,9 @@ async function getOrganizationTags({ organizationId, db }: { organizationId: str
     .leftJoin(documentsTagsTable, eq(tagsTable.id, documentsTagsTable.tagId))
     .leftJoin(documentsTable, eq(documentsTagsTable.documentId, documentsTable.id))
     .where(eq(tagsTable.organizationId, organizationId))
-    .groupBy(tagsTable.id);
+    .groupBy(tagsTable.id)
+    // NOTE: I've chosen the _name_ to be the default sorting; by modifying this, tags now appear alphabetically sorted pretty much everywhere in the UI
+    .orderBy(tagsTable.name);
 
   return { tags };
 }


### PR DESCRIPTION
This PR modifies the Tag repository to return tags in ordered fashion, so that they appear sorted to the user. **This may not be the correct place to do so, and instead we might want to sort on the client side**, but that's a decision I cannot make as someone very new to this project.

It also includes a note in the repository test, but no implementation in case this change is undesired.

Related to https://github.com/papra-hq/papra/issues/469; fixes the comment that tags are "wildly sorted".