### PR TITLE
fix: delete orphan file when duplicate hash is found

### DIFF
--- a/.changeset/silent-gifts-enjoy.md
+++ b/.changeset/silent-gifts-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@papra/docker": patch
+---
+
+Properly cleanup orphan file when the same document exists in trash

--- a/apps/papra-server/src/modules/documents/documents.usecases.ts
+++ b/apps/papra-server/src/modules/documents/documents.usecases.ts
@@ -235,9 +235,10 @@ async function handleExistingDocument({
   newDocumentStorageKey: string;
   logger: Logger;
 }) {
-  if (!existingDocument.isDeleted) {
-    await documentsStorageService.deleteFile({ storageKey: newDocumentStorageKey });
+  // Delete the newly uploaded file since we'll be using the existing document's file
+  await documentsStorageService.deleteFile({ storageKey: newDocumentStorageKey });
 
+  if (!existingDocument.isDeleted) {
     throw createDocumentAlreadyExistsError();
   }
 


### PR DESCRIPTION
Fixes an issue where orphan files were left in the originals folder when uploading duplicate files (same hash).

## Solution
Delete the newly uploaded file immediately at the start of `handleExistingDocument` since:
- If existing doc is NOT deleted → we throw an error, so we don't need the new file
- If existing doc IS deleted → we restore the old document (which already has its file), so we don't need the new file either

Fixes #714 