### PR TITLE
Shrink rootless image size

### DIFF
--- a/packages/app/Dockerfile.rootless
+++ b/packages/app/Dockerfile.rootless
@@ -44,13 +44,13 @@ RUN groupadd -r nonroot && useradd -r -g nonroot nonroot && \
 
 WORKDIR /app
 
-COPY --from=build /prod/papra-server ./
-COPY --from=build /app/apps/papra-client/dist ./public
-
 RUN mkdir -p ./app-data/db ./app-data/documents && chown -R nonroot:nonroot /app
 
 # Switch to nonroot user
 USER nonroot
+
+COPY --from=build --chown=nonroot:nonroot /prod/papra-server ./
+COPY --from=build --chown=nonroot:nonroot /app/apps/papra-client/dist ./public
 
 EXPOSE 1221
 


### PR DESCRIPTION
I took a look into the rootless image using [dive](https://github.com/wagoodman/dive) and noticed the `/app/node_modules` folder existing twice in the image.  
This happens because the `chown -R nonroot:nonroot /app` in [L50](https://github.com/papra-hq/papra/blob/c120be8bd6e8b892394c52ad60947ac9a687673f/packages/app/Dockerfile.rootless#L50) duplicates every file where it changes the permission. I reordered the commands in 67358b2db880a8a8f4df288306de90f6cfc783f3, and changed the COPY to use the `chown` option. This reduced the image size by ~1/3. With this change the root and rootless image have the same size when I build them locally.  
The second commit c475d2cafada44d9947951d1501c49985abd7b23 only removes around 20MB, by avoiding duplicated corepack files. If you are happy with the change it might make sense to also add it to the Dockerfile for root.  

I only checked that papra started without any errors, and am not familiar with node.  If there is a reason to reuse `base` for the final image the second commit can be dropped.


# Reference:

## Dive view for rootless-26.1.0

<img width="1277" height="1261" alt="image" src="https://github.com/user-attachments/assets/64fb268c-5230-4d3e-b461-35b49033585b" />

## Dive view for 67358b2db880a8a8f4df288306de90f6cfc783f3
<img width="925" height="1022" alt="image" src="https://github.com/user-attachments/assets/f9da2d98-ca38-468d-9ac6-51de1f643f34" />


## Dive view for c475d2cafada44d9947951d1501c49985abd7b23
The shown duplicated package manager files are, from a cursory check, coming from your base image, i.e. nothing to be done without using a different base image
<img width="1277" height="1261" alt="image" src="https://github.com/user-attachments/assets/0b3066f2-68e5-40c9-b571-66698ff99ad2" />
