### PR TITLE
feat(docker): add health check to Dockerfiles

### DIFF
--- a/apps/papra-server/Dockerfile
+++ b/apps/papra-server/Dockerfile
@@ -53,5 +53,8 @@ COPY --from=build /app/production /app
 
 EXPOSE 1221
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s \
+    CMD node -e "fetch('http://localhost:1221/api/health').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"
+
 # The command is overridden by Fly at runtime, see ./fly.toml
 CMD [ "pnpm", "--silent", "start:with-migrations" ]

--- a/packages/app/Dockerfile
+++ b/packages/app/Dockerfile
@@ -59,4 +59,7 @@ ENV BETTER_AUTH_TELEMETRY=0
 
 RUN mkdir -p ./app-data/db ./app-data/documents ./ingestion
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s \
+    CMD node -e "fetch('http://localhost:1221/api/health').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"
+
 CMD ["pnpm", "start:with-migrations"]

--- a/packages/app/Dockerfile.rootless
+++ b/packages/app/Dockerfile.rootless
@@ -70,4 +70,7 @@ ENV CLIENT_BASE_URL=http://localhost:1221
 # Disable Better Auth telemetry
 ENV BETTER_AUTH_TELEMETRY=0
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s \
+    CMD node -e "fetch('http://localhost:1221/api/health').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"
+
 CMD ["pnpm", "start:with-migrations"]


### PR DESCRIPTION
## Summary

Add `HEALTHCHECK` instruction to all three Dockerfiles, using the existing
`/api/health` endpoint on port 1221.

## Changes

Added the following to `packages/app/Dockerfile`, `packages/app/Dockerfile.rootless`,
and `apps/papra-server/Dockerfile`:

```dockerfile
HEALTHCHECK --interval=30s --timeout=5s --start-period=10s \
    CMD node -e "fetch('http://localhost:1221/api/health').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"
```

Uses Node.js native `fetch` (available in Node 24) to call the health endpoint.
No extra packages like `curl` or `wget` needed. The health endpoint
(`/api/health` in `health-check.routes.ts`) returns HTTP 200 when the database
is healthy and HTTP 500 otherwise.

## Testing

- Verified the `/api/health` route exists and returns `{status: "ok"}` on 200
  and `{status: "error"}` on 500 (see `health-check.routes.ts` and
  `health-check.e2e.test.ts`)
- Dockerfile syntax validated

Closes #691

This contribution was developed with AI assistance (Claude Code + Codex).