### PR TITLE
fix: preserve correct extension on document download

### DIFF
--- a/apps/papra-server/src/modules/documents/documents.routes.ts
+++ b/apps/papra-server/src/modules/documents/documents.routes.ts
@@ -9,6 +9,7 @@ import { createOrganizationsRepository } from '../organizations/organizations.re
 import { ensureUserIsInOrganization } from '../organizations/organizations.usecases';
 import { createPlansRepository } from '../plans/plans.repository';
 import { getOrganizationPlan } from '../plans/plans.usecases';
+import { getDownloadFileName } from '../shared/files/file-names';
 import { createQueryPaginationSchemaKeys } from '../shared/schemas/pagination.schemas';
 import { getFileStreamFromMultipartForm } from '../shared/streams/file-upload';
 import { validateJsonBody, validateParams, validateQuery } from '../shared/validation/validation';
@@ -238,6 +239,8 @@ function setupGetDocumentFileRoute({ app, db, documentsStorageService }: RouteDe
         fileEncryptionKeyWrapped: document.fileEncryptionKeyWrapped,
       });
 
+      const downloadFileName = getDownloadFileName({ name: document.name, mimeType: document.mimeType });
+
       return context.body(
         Readable.toWeb(fileStream),
         200,
@@ -245,7 +248,7 @@ function setupGetDocumentFileRoute({ app, db, documentsStorageService }: RouteDe
           // Prevent XSS by serving the file as an octet-stream
           'Content-Type': 'application/octet-stream',
           // Always use attachment for defense in depth - client uses blob API anyway
-          'Content-Disposition': `attachment; filename*=UTF-8''${encodeURIComponent(document.name)}`,
+          'Content-Disposition': `attachment; filename*=UTF-8''${encodeURIComponent(downloadFileName)}`,
           'Content-Length': String(document.originalSize),
           'X-Content-Type-Options': 'nosniff',
           'X-Frame-Options': 'DENY',

--- a/apps/papra-server/src/modules/shared/files/file-names.test.ts
+++ b/apps/papra-server/src/modules/shared/files/file-names.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { getExtension } from './file-names';
+import { getDownloadFileName, getExtension } from './file-names';
 
 describe('extensions', () => {
   describe('getExtension', () => {
@@ -13,6 +13,35 @@ describe('extensions', () => {
       expect(getExtension({ fileName: 'file.' })).to.eql({ extension: undefined });
       expect(getExtension({ fileName: '' })).to.eql({ extension: undefined });
       expect(getExtension({ fileName: '.' })).to.eql({ extension: undefined });
+    });
+  });
+
+  describe('getDownloadFileName', () => {
+    test('appends the canonical extension when the renamed document has none', () => {
+      expect(getDownloadFileName({ name: 'Q1 Report', mimeType: 'application/pdf' })).to.eql('Q1 Report.pdf');
+      expect(getDownloadFileName({ name: 'invoice', mimeType: 'image/png' })).to.eql('invoice.png');
+    });
+
+    test('keeps the file name unchanged when it already has the correct extension', () => {
+      expect(getDownloadFileName({ name: 'report.pdf', mimeType: 'application/pdf' })).to.eql('report.pdf');
+      expect(getDownloadFileName({ name: 'archive.test.pdf', mimeType: 'application/pdf' })).to.eql('archive.test.pdf');
+    });
+
+    test('matches extensions case-insensitively', () => {
+      expect(getDownloadFileName({ name: 'report.PDF', mimeType: 'application/pdf' })).to.eql('report.PDF');
+    });
+
+    test('appends the canonical extension when the existing one does not match the mime type', () => {
+      expect(getDownloadFileName({ name: 'report.txt', mimeType: 'application/pdf' })).to.eql('report.txt.pdf');
+    });
+
+    test('preserves dots in the document name when there is no real extension', () => {
+      expect(getDownloadFileName({ name: 'Document v1.0', mimeType: 'application/pdf' })).to.eql('Document v1.0.pdf');
+    });
+
+    test('returns the name unchanged for unknown or generic mime types', () => {
+      expect(getDownloadFileName({ name: 'unknown', mimeType: 'application/octet-stream' })).to.eql('unknown');
+      expect(getDownloadFileName({ name: 'unknown', mimeType: 'application/x-not-a-real-type' })).to.eql('unknown');
     });
   });
 });

--- a/apps/papra-server/src/modules/shared/files/file-names.ts
+++ b/apps/papra-server/src/modules/shared/files/file-names.ts
@@ -1,3 +1,5 @@
+import mime from 'mime-types';
+
 export function getExtension({ fileName }: { fileName: string }) {
   const parts = fileName.split('.');
 
@@ -24,4 +26,25 @@ export function getFileNameWithoutExtension({ fileName }: { fileName: string }) 
   const fileNameWithoutExtension = parts.slice(0, -1).join('.');
 
   return { fileNameWithoutExtension };
+}
+
+export function getDownloadFileName({ name, mimeType }: { name: string; mimeType: string }): string {
+  // Skip generic mime types — appending `.bin` to a renamed document is more confusing than no extension
+  if (mimeType === 'application/octet-stream') {
+    return name;
+  }
+
+  const expectedExtension = mime.extension(mimeType);
+
+  if (expectedExtension === false) {
+    return name;
+  }
+
+  const { extension: currentExtension } = getExtension({ fileName: name });
+
+  if (currentExtension?.toLowerCase() === expectedExtension) {
+    return name;
+  }
+
+  return `${name}.${expectedExtension}`;
 }


### PR DESCRIPTION
## What does this PR do?

When a document is renamed in Papra and the new name no longer ends with the original extension, downloading it serves the file without a (or with the wrong) extension — users have to manually rename the file before they can open it.

This PR fixes the download endpoint to derive the canonical extension from the stored \`mimeType\` and ensure the downloaded file name carries it.

Closes #952

## How was it done?

Added a small \`getDownloadFileName\` helper in \`apps/papra-server/src/modules/shared/files/file-names.ts\` that:

1. Returns the name unchanged when the mime type is \`application/octet-stream\` (appending \`.bin\` to a user-named document would be more confusing than no extension)
2. Returns the name unchanged when the mime type isn't recognized by \`mime-types\`
3. Returns the name unchanged when the existing extension already matches (case-insensitive)
4. Otherwise appends the canonical extension for the mime type

The download route in \`documents.routes.ts\` now passes the result of this helper to the \`Content-Disposition\` header instead of the raw \`document.name\`.

## How was it tested?

Added 6 unit tests in \`file-names.test.ts\` covering:
- Renamed document with no extension (\`Q1 Report\` + \`application/pdf\` → \`Q1 Report.pdf\`)
- Document already has correct extension (no change)
- Case-insensitive matching (\`report.PDF\` left alone)
- Existing extension doesn't match mime type (appended)
- Document name with dots that aren't extensions (\`Document v1.0\`)
- Generic/unknown mime types (no change)

All 8 tests in the file pass (\`pnpm vitest run src/modules/shared/files/file-names.test.ts\`).