### PR TITLE
fix: do not strip name suffixes that are not the original file extension

### DIFF
--- a/apps/papra-client/src/modules/documents/components/document-management-dropdown.component.tsx
+++ b/apps/papra-client/src/modules/documents/components/document-management-dropdown.component.tsx
@@ -74,6 +74,7 @@ export const DocumentManagementDropdown: Component<{ document: Document }> = (pr
             documentId: props.document.id,
             organizationId: props.document.organizationId,
             documentName: props.document.name,
+            documentOriginalName: props.document.originalName,
           })}
         >
           <div class="i-tabler-pencil size-4 mr-2" />

--- a/apps/papra-client/src/modules/documents/components/documents-list.component.tsx
+++ b/apps/papra-client/src/modules/documents/components/documents-list.component.tsx
@@ -107,11 +107,12 @@ export const DocumentsPaginatedList: Component<{
               >
                 {getDocumentNameWithoutExtension({
                   name: data.row.original.name,
+                  originalName: data.row.original.originalName,
                 })}
               </A>
 
               <div class="text-xs text-muted-foreground lh-tight">
-                {[formatBytes({ bytes: data.row.original.originalSize, base: 1000 }), getDocumentNameExtension({ name: data.row.original.name })].filter(Boolean).join(' - ')}
+                {[formatBytes({ bytes: data.row.original.originalSize, base: 1000 }), getDocumentNameExtension({ name: data.row.original.name, originalName: data.row.original.originalName })].filter(Boolean).join(' - ')}
                 {' '}
                 -
                 {' '}

--- a/apps/papra-client/src/modules/documents/components/rename-document-button.component.tsx
+++ b/apps/papra-client/src/modules/documents/components/rename-document-button.component.tsx
@@ -17,6 +17,7 @@ export const RenameDocumentDialog: Component<{
   documentId: string;
   organizationId: string;
   documentName: string;
+  documentOriginalName?: string;
   isOpen: boolean;
   setIsOpen: (isOpen: boolean) => void;
 }> = (props) => {
@@ -47,10 +48,10 @@ export const RenameDocumentDialog: Component<{
       ),
     }),
     initialValues: {
-      name: getDocumentNameWithoutExtension({ name: props.documentName }),
+      name: getDocumentNameWithoutExtension({ name: props.documentName, originalName: props.documentOriginalName }),
     },
     onSubmit: async ({ name }) => {
-      const extension = getDocumentNameExtension({ name: props.documentName });
+      const extension = getDocumentNameExtension({ name: props.documentName, originalName: props.documentOriginalName });
       const newName = extension ? `${name}.${extension}` : name;
 
       await renameDocumentMutation.mutateAsync({ name: newName });
@@ -58,7 +59,7 @@ export const RenameDocumentDialog: Component<{
   });
 
   createEffect(() => {
-    setValue(form, 'name', getDocumentNameWithoutExtension({ name: props.documentName }));
+    setValue(form, 'name', getDocumentNameWithoutExtension({ name: props.documentName, originalName: props.documentOriginalName }));
   });
 
   return (
@@ -92,7 +93,7 @@ export const RenameDocumentDialog: Component<{
 };
 
 const context = createContext<{
-  openRenameDialog: (args: { documentId: string; organizationId: string; documentName: string }) => void;
+  openRenameDialog: (args: { documentId: string; organizationId: string; documentName: string; documentOriginalName?: string }) => void;
 }>();
 
 export function useRenameDocumentDialog() {
@@ -110,15 +111,17 @@ export const RenameDocumentDialogProvider: ParentComponent = (props) => {
   const [getDocumentId, setDocumentId] = createSignal<string | undefined>(undefined);
   const [getOrganizationId, setOrganizationId] = createSignal<string | undefined>(undefined);
   const [getDocumentName, setDocumentName] = createSignal<string | undefined>(undefined);
+  const [getDocumentOriginalName, setDocumentOriginalName] = createSignal<string | undefined>(undefined);
 
   return (
     <context.Provider
       value={{
-        openRenameDialog: ({ documentId, organizationId, documentName }) => {
+        openRenameDialog: ({ documentId, organizationId, documentName, documentOriginalName }) => {
           setIsRenameDialogOpen(true);
           setDocumentId(documentId);
           setOrganizationId(organizationId);
           setDocumentName(documentName);
+          setDocumentOriginalName(documentOriginalName);
         },
       }}
     >
@@ -126,6 +129,7 @@ export const RenameDocumentDialogProvider: ParentComponent = (props) => {
         documentId={getDocumentId() ?? ''}
         organizationId={getOrganizationId() ?? ''}
         documentName={getDocumentName() ?? ''}
+        documentOriginalName={getDocumentOriginalName()}
         isOpen={getIsRenameDialogOpen()}
         setIsOpen={setIsRenameDialogOpen}
       />

--- a/apps/papra-client/src/modules/documents/document.models.test.ts
+++ b/apps/papra-client/src/modules/documents/document.models.test.ts
@@ -244,6 +244,20 @@ describe('files models', () => {
       expect(getDocumentNameWithoutExtension({ name: '.document.txt' })).to.eql('.document');
       expect(getDocumentNameWithoutExtension({ name: 'document.test.txt' })).to.eql('document.test');
     });
+
+    test('does not strip suffixes that are not the original extension', () => {
+      expect(getDocumentNameWithoutExtension({ name: 'Document v1.0', originalName: 'report.pdf' })).to.eql('Document v1.0');
+      expect(getDocumentNameWithoutExtension({ name: 'My File.Apartment.Address', originalName: 'doc.pdf' })).to.eql('My File.Apartment.Address');
+    });
+
+    test('strips the extension when name still ends with the original extension', () => {
+      expect(getDocumentNameWithoutExtension({ name: 'Q1 Report.pdf', originalName: 'report.pdf' })).to.eql('Q1 Report');
+      expect(getDocumentNameWithoutExtension({ name: 'final.PDF', originalName: 'draft.pdf' })).to.eql('final');
+    });
+
+    test('does not strip anything when the original upload had no extension', () => {
+      expect(getDocumentNameWithoutExtension({ name: 'Document v1.0', originalName: 'README' })).to.eql('Document v1.0');
+    });
   });
 
   describe('getDocumentNameExtension', () => {
@@ -253,6 +267,19 @@ describe('files models', () => {
       expect(getDocumentNameExtension({ name: '.document' })).to.eql(undefined);
       expect(getDocumentNameExtension({ name: '.document.txt' })).to.eql('txt');
       expect(getDocumentNameExtension({ name: 'document.test.txt' })).to.eql('txt');
+    });
+
+    test('returns undefined when name suffix does not match original extension', () => {
+      expect(getDocumentNameExtension({ name: 'Document v1.0', originalName: 'report.pdf' })).to.eql(undefined);
+      expect(getDocumentNameExtension({ name: 'My File.Apartment.Address', originalName: 'doc.pdf' })).to.eql(undefined);
+    });
+
+    test('returns the extension when name still ends with the original extension', () => {
+      expect(getDocumentNameExtension({ name: 'Q1 Report.pdf', originalName: 'report.pdf' })).to.eql('pdf');
+    });
+
+    test('returns undefined when the original upload had no extension', () => {
+      expect(getDocumentNameExtension({ name: 'Document v1.0', originalName: 'README' })).to.eql(undefined);
     });
   });
 

--- a/apps/papra-client/src/modules/documents/document.models.ts
+++ b/apps/papra-client/src/modules/documents/document.models.ts
@@ -136,22 +136,7 @@ export function getDaysBeforePermanentDeletion({ document, deletedDocumentsReten
   return daysBeforeDeletion;
 }
 
-export function getDocumentNameWithoutExtension({ name }: { name: string }) {
-  const dotSplittedName = name.split('.');
-  const dotCount = dotSplittedName.length - 1;
-
-  if (dotCount === 0) {
-    return name;
-  }
-
-  if (dotCount === 1 && name.startsWith('.')) {
-    return name;
-  }
-
-  return dotSplittedName.slice(0, -1).join('.');
-}
-
-export function getDocumentNameExtension({ name }: { name: string }) {
+function getRawNameExtension(name: string): string | undefined {
   const dotSplittedName = name.split('.');
   const dotCount = dotSplittedName.length - 1;
 
@@ -164,6 +149,43 @@ export function getDocumentNameExtension({ name }: { name: string }) {
   }
 
   return dotSplittedName[dotCount];
+}
+
+// When `originalName` is provided, the extension is only recognised if `name` still ends with the
+// same extension as the original upload — this prevents stripping suffixes from user-renamed
+// documents like "Document v1.0" where ".0" is part of the name, not a file extension.
+export function getDocumentNameWithoutExtension({ name, originalName }: { name: string; originalName?: string }) {
+  const extension = getDocumentNameExtension({ name, originalName });
+
+  if (extension === undefined) {
+    return name;
+  }
+
+  return name.slice(0, -(extension.length + 1));
+}
+
+export function getDocumentNameExtension({ name, originalName }: { name: string; originalName?: string }) {
+  const rawExtension = getRawNameExtension(name);
+
+  if (rawExtension === undefined) {
+    return undefined;
+  }
+
+  if (originalName === undefined) {
+    return rawExtension;
+  }
+
+  const originalExtension = getRawNameExtension(originalName);
+
+  if (originalExtension === undefined) {
+    return undefined;
+  }
+
+  if (rawExtension.toLowerCase() !== originalExtension.toLowerCase()) {
+    return undefined;
+  }
+
+  return rawExtension;
 }
 
 export const documentActivityIcon: Record<DocumentActivityEvent, string> = {

--- a/apps/papra-client/src/modules/documents/documents.types.ts
+++ b/apps/papra-client/src/modules/documents/documents.types.ts
@@ -7,6 +7,7 @@ export type Document = {
   id: string;
   organizationId: string;
   name: string;
+  originalName?: string;
   mimeType: string;
   originalSize: number;
   createdAt: Date;

--- a/apps/papra-client/src/modules/documents/pages/document.page.tsx
+++ b/apps/papra-client/src/modules/documents/pages/document.page.tsx
@@ -213,6 +213,7 @@ export const DocumentPage: Component = () => {
                       documentId: getDocument().id,
                       organizationId: params.organizationId,
                       documentName: getDocument().name,
+                      documentOriginalName: getDocument().originalName,
                     })}
                   >
                     <h1 class="text-xl font-semibold lh-tight" title={getDocument().name}>
@@ -304,6 +305,7 @@ export const DocumentPage: Component = () => {
                                   documentId: getDocument().id,
                                   organizationId: params.organizationId,
                                   documentName: getDocument().name,
+                                  documentOriginalName: getDocument().originalName,
                                 })}
                               >
                                 {getDocument().name}


### PR DESCRIPTION
## What does this PR do?

Fixes the buggy display of document names containing dots (e.g. \`Document v1.0\`, \`My File.Apartment.Address\`) in the documents list. The list view was stripping anything after the last dot as the extension, even when the document had been renamed and the suffix wasn't a real file extension.

Closes #927

## How was it done?

The display logic now uses the document's \`originalName\` (the name at upload time) to decide whether the trailing suffix on \`name\` is a real extension:

- If \`originalName\` has no extension → no stripping
- If \`name\`'s suffix doesn't match the extension from \`originalName\` (case-insensitive) → no stripping
- Otherwise → strip the extension

\`originalName\` is now optional on the client \`Document\` type and is threaded through to:
- The documents list cell (main label and subtitle)
- The \`RenameDocumentDialog\` (so the input field shows the right starting value and the saved name re-appends the right extension)

When \`originalName\` is not provided, the function falls back to the previous dot-splitting behaviour, so this is fully backwards-compatible.

## How was it tested?

Added 5 unit tests in \`document.models.test.ts\` covering:
- Renamed documents with non-extension suffixes (\`Document v1.0\` + \`report.pdf\` originalName → no stripping)
- Renamed documents that still have the original extension (\`Q1 Report.pdf\` + \`report.pdf\` → \`Q1 Report\`)
- Case-insensitive extension matching (\`final.PDF\` + \`draft.pdf\` → \`final\`)
- Documents whose original upload had no extension (\`README\`-style)

All 39 tests in \`document.models.test.ts\` pass (\`pnpm vitest run src/modules/documents/document.models.test.ts\`).