### PR TITLE
chore(api-sdk): add package homepage metadata

### DIFF
--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -2,6 +2,7 @@
   "name": "@papra/api-sdk",
   "version": "1.3.0",
   "description": "Api SDK for Papra, the document archiving platform.",
+  "homepage": "https://github.com/papra-hq/papra/tree/main/packages/api-sdk#readme",
   "keywords": [
     "api",
     "archiving",


### PR DESCRIPTION
## Summary
- add npm homepage metadata for the API SDK package
- point the homepage to the package README in this repository

## Verification
- npm view @papra/api-sdk@latest name version license homepage bugs repository --json
- GitHub API manifest assertion for name/version/homepage/bugs/repository
- GitHub commit diff confirms only packages/api-sdk/package.json changed