### PR TITLE
Fix S3 checksum config for Backblaze B2

### DIFF
--- a/apps/papra-server/src/modules/documents/storage/drivers/s3/s3.storage-driver.ts
+++ b/apps/papra-server/src/modules/documents/storage/drivers/s3/s3.storage-driver.ts
@@ -38,6 +38,8 @@ export const s3StorageDriverFactory = defineStorageDriver(({ documentStorageConf
       secretAccessKey,
     },
     forcePathStyle,
+    requestChecksumCalculation: 'WHEN_REQUIRED',
+    responseChecksumValidation: 'WHEN_REQUIRED',
   });
 
   const fileExists = async ({ storageKey }: { storageKey: string }) => {


### PR DESCRIPTION
This fixes compatibility issues with S3-compatible providers such as b2.
Resolves #1166 

I've tested this with my deployment and can confirm upload works fine with this patch.