### PR TITLE
feat: Sort by document date and display as a table column

### DIFF
--- a/.changeset/silver-months-sin.md
+++ b/.changeset/silver-months-sin.md
@@ -1,0 +1,5 @@
+---
+'@papra/app': patch
+---
+
+Sort documents by document date instead of the created date.

--- a/apps/papra-client/src/locales/de.dictionary.ts
+++ b/apps/papra-client/src/locales/de.dictionary.ts
@@ -403,6 +403,7 @@ export const translations: Partial<TranslationsDictionary> = {
   'documents.info.updated-at': 'Aktualisiert am',
   'documents.info.never': 'Nie',
   'documents.info.document-date': 'Datum',
+  'documents.list.table.headers.document-date': 'Datum',
   'documents.info.no-date': 'Kein Datum',
   'documents.info.today': 'Heute',
 

--- a/apps/papra-client/src/locales/el.dictionary.ts
+++ b/apps/papra-client/src/locales/el.dictionary.ts
@@ -393,6 +393,7 @@ export const translations: Partial<TranslationsDictionary> = {
   'documents.info.updated-at': 'Ημερομηνία ενημέρωσης',
   'documents.info.never': 'Ποτέ',
   'documents.info.document-date': 'Ημερομηνία',
+  'documents.list.table.headers.document-date': 'Ημερομηνία',
   'documents.info.no-date': 'Χωρίς ημερομηνία',
   'documents.info.today': 'Σήμερα',
 

--- a/apps/papra-client/src/locales/en.dictionary.ts
+++ b/apps/papra-client/src/locales/en.dictionary.ts
@@ -352,6 +352,7 @@ export const translations = {
     'There are no documents in this organization yet. Start by uploading some documents.',
   'documents.list.no-results': 'No documents found',
   'documents.list.table.headers.file-name': 'File name',
+  'documents.list.table.headers.document-date': 'Date',
   'documents.list.table.headers.created': 'Created',
   'documents.list.table.headers.deleted': 'Deleted',
   'documents.list.table.headers.actions': 'Actions',

--- a/apps/papra-client/src/locales/es.dictionary.ts
+++ b/apps/papra-client/src/locales/es.dictionary.ts
@@ -398,6 +398,7 @@ export const translations: Partial<TranslationsDictionary> = {
   'documents.info.updated-at': 'Actualizado el',
   'documents.info.never': 'Nunca',
   'documents.info.document-date': 'Fecha',
+  'documents.list.table.headers.document-date': 'Fecha',
   'documents.info.no-date': 'Sin fecha',
   'documents.info.today': 'Hoy',
 

--- a/apps/papra-client/src/locales/fr.dictionary.ts
+++ b/apps/papra-client/src/locales/fr.dictionary.ts
@@ -399,6 +399,7 @@ export const translations: Partial<TranslationsDictionary> = {
   'documents.info.updated-at': 'Mis à jour le',
   'documents.info.never': 'Jamais',
   'documents.info.document-date': 'Date',
+  'documents.list.table.headers.document-date': 'Date',
   'documents.info.no-date': 'Pas de date',
   'documents.info.today': "Aujourd'hui",
 

--- a/apps/papra-client/src/locales/it.dictionary.ts
+++ b/apps/papra-client/src/locales/it.dictionary.ts
@@ -398,6 +398,7 @@ export const translations: Partial<TranslationsDictionary> = {
   'documents.info.updated-at': 'Aggiornato il',
   'documents.info.never': 'Mai',
   'documents.info.document-date': 'Data',
+  'documents.list.table.headers.document-date': 'Data',
   'documents.info.no-date': 'Nessuna data',
   'documents.info.today': 'Oggi',
 

--- a/apps/papra-client/src/locales/nl.dictionary.ts
+++ b/apps/papra-client/src/locales/nl.dictionary.ts
@@ -397,6 +397,7 @@ export const translations: Partial<TranslationsDictionary> = {
   'documents.info.updated-at': 'Bijgewerkt op',
   'documents.info.never': 'Nooit',
   'documents.info.document-date': 'Datum',
+  'documents.list.table.headers.document-date': 'Datum',
   'documents.info.no-date': 'Geen datum',
   'documents.info.today': 'Vandaag',
 

--- a/apps/papra-client/src/locales/pl.dictionary.ts
+++ b/apps/papra-client/src/locales/pl.dictionary.ts
@@ -391,6 +391,7 @@ export const translations: Partial<TranslationsDictionary> = {
   'documents.info.updated-at': 'Zaktualizowano',
   'documents.info.never': 'Nigdy',
   'documents.info.document-date': 'Data',
+  'documents.list.table.headers.document-date': 'Data',
   'documents.info.no-date': 'Brak daty',
   'documents.info.today': 'Dzisiaj',
 

--- a/apps/papra-client/src/locales/pt-BR.dictionary.ts
+++ b/apps/papra-client/src/locales/pt-BR.dictionary.ts
@@ -393,6 +393,7 @@ export const translations: Partial<TranslationsDictionary> = {
   'documents.info.updated-at': 'Atualizado em',
   'documents.info.never': 'Nunca',
   'documents.info.document-date': 'Data',
+  'documents.list.table.headers.document-date': 'Data',
   'documents.info.no-date': 'Sem data',
   'documents.info.today': 'Hoje',
 

--- a/apps/papra-client/src/locales/pt.dictionary.ts
+++ b/apps/papra-client/src/locales/pt.dictionary.ts
@@ -402,6 +402,7 @@ export const translations: Partial<TranslationsDictionary> = {
   'documents.info.updated-at': 'Atualizado em',
   'documents.info.never': 'Nunca',
   'documents.info.document-date': 'Data',
+  'documents.list.table.headers.document-date': 'Data',
   'documents.info.no-date': 'Sem data',
   'documents.info.today': 'Hoje',
 

--- a/apps/papra-client/src/locales/ro.dictionary.ts
+++ b/apps/papra-client/src/locales/ro.dictionary.ts
@@ -395,6 +395,7 @@ export const translations: Partial<TranslationsDictionary> = {
   'documents.info.updated-at': 'Actualizat la',
   'documents.info.never': 'Niciodată',
   'documents.info.document-date': 'Data',
+  'documents.list.table.headers.document-date': 'Data',
   'documents.info.no-date': 'Fără dată',
   'documents.info.today': 'Astăzi',
 

--- a/apps/papra-client/src/locales/ru.dictionary.ts
+++ b/apps/papra-client/src/locales/ru.dictionary.ts
@@ -390,6 +390,7 @@ export const translations: Partial<TranslationsDictionary> = {
   'documents.info.updated-at': 'Обновлён',
   'documents.info.never': 'Никогда',
   'documents.info.document-date': 'Дата',
+  'documents.list.table.headers.document-date': 'Дата',
   'documents.info.no-date': 'Нет даты',
   'documents.info.today': 'Сегодня',
 

--- a/apps/papra-client/src/locales/sv.dictionary.ts
+++ b/apps/papra-client/src/locales/sv.dictionary.ts
@@ -394,6 +394,7 @@ export const translations: Partial<TranslationsDictionary> = {
   'documents.info.updated-at': 'Uppdaterad',
   'documents.info.never': 'Aldrig',
   'documents.info.document-date': 'Datum',
+  'documents.list.table.headers.document-date': 'Datum',
   'documents.info.no-date': 'Inget datum',
   'documents.info.today': 'Idag',
 

--- a/apps/papra-client/src/locales/zh.dictionary.ts
+++ b/apps/papra-client/src/locales/zh.dictionary.ts
@@ -365,6 +365,7 @@ export const translations: Partial<TranslationsDictionary> = {
   'documents.info.updated-at': '更新时间',
   'documents.info.never': '从不',
   'documents.info.document-date': '日期',
+  'documents.list.table.headers.document-date': '日期',
   'documents.info.no-date': '无日期',
   'documents.info.today': '今天',
 

--- a/apps/papra-client/src/modules/document-views/pages/document-view.page.tsx
+++ b/apps/papra-client/src/modules/document-views/pages/document-view.page.tsx
@@ -171,7 +171,12 @@ export const DocumentViewPage: Component = () => {
                     documentsCount={getData().documentsCount}
                     getPagination={getPagination}
                     setPagination={setPagination}
-                    extraColumns={[tagsColumn, documentDateColumn, createdAtColumn, standardActionsColumn]}
+                    extraColumns={[
+                      tagsColumn,
+                      documentDateColumn,
+                      createdAtColumn,
+                      standardActionsColumn,
+                    ]}
                   />
                 )}
               </Show>

--- a/apps/papra-client/src/modules/document-views/pages/document-view.page.tsx
+++ b/apps/papra-client/src/modules/document-views/pages/document-view.page.tsx
@@ -6,6 +6,7 @@ import { keepPreviousData, useQuery } from '@tanstack/solid-query';
 import { createSignal, Show, Suspense } from 'solid-js';
 import {
   createdAtColumn,
+  documentDateColumn,
   DocumentsPaginatedList,
   standardActionsColumn,
   tagsColumn,
@@ -170,7 +171,7 @@ export const DocumentViewPage: Component = () => {
                     documentsCount={getData().documentsCount}
                     getPagination={getPagination}
                     setPagination={setPagination}
-                    extraColumns={[tagsColumn, createdAtColumn, standardActionsColumn]}
+                    extraColumns={[tagsColumn, documentDateColumn, createdAtColumn, standardActionsColumn]}
                   />
                 )}
               </Show>

--- a/apps/papra-client/src/modules/documents/components/documents-list.component.tsx
+++ b/apps/papra-client/src/modules/documents/components/documents-list.component.tsx
@@ -75,10 +75,14 @@ export const documentDateColumn: ColumnDef<Document> = {
   accessorKey: 'documentDate',
   enableSorting: true,
   cell: (data) => {
+    const { t } = useI18n();
     const value = data.getValue<Date | null | undefined>();
     return (
       <span class="text-muted-foreground hidden sm:block">
-        <Show when={value} fallback="—">
+        <Show
+          when={value}
+          fallback={<span class="text-muted-foreground/50">{t('documents.info.no-date')}</span>}
+        >
           {(date) => <RelativeTime date={date()} />}
         </Show>
       </span>

--- a/apps/papra-client/src/modules/documents/components/documents-list.component.tsx
+++ b/apps/papra-client/src/modules/documents/components/documents-list.component.tsx
@@ -67,6 +67,25 @@ const selectionColumn: ColumnDef<Document> = {
   enableHiding: false,
 };
 
+export const documentDateColumn: ColumnDef<Document> = {
+  header: () => {
+    const { t } = useI18n();
+    return <span class="hidden sm:block">{t('documents.list.table.headers.document-date')}</span>;
+  },
+  accessorKey: 'documentDate',
+  enableSorting: true,
+  cell: (data) => {
+    const value = data.getValue<Date | null | undefined>();
+    return (
+      <span class="text-muted-foreground hidden sm:block">
+        <Show when={value} fallback="—">
+          {(date) => <RelativeTime date={date()} />}
+        </Show>
+      </span>
+    );
+  },
+};
+
 export const createdAtColumn: ColumnDef<Document> = {
   header: () => {
     const { t } = useI18n();

--- a/apps/papra-client/src/modules/documents/documents.constants.ts
+++ b/apps/papra-client/src/modules/documents/documents.constants.ts
@@ -24,5 +24,5 @@ export type DocumentSearchSortField = (typeof DOCUMENT_SEARCH_SORT_FIELDS)[numbe
 export const DOCUMENT_SEARCH_SORT_ORDERS = ['asc', 'desc'] as const;
 export type DocumentSearchSortOrder = (typeof DOCUMENT_SEARCH_SORT_ORDERS)[number];
 
-export const DEFAULT_DOCUMENT_SEARCH_SORT_FIELD: DocumentSearchSortField = 'createdAt';
+export const DEFAULT_DOCUMENT_SEARCH_SORT_FIELD: DocumentSearchSortField = 'documentDate';
 export const DEFAULT_DOCUMENT_SEARCH_SORT_ORDER: DocumentSearchSortOrder = 'desc';

--- a/apps/papra-client/src/modules/documents/pages/documents.page.tsx
+++ b/apps/papra-client/src/modules/documents/pages/documents.page.tsx
@@ -21,6 +21,7 @@ import { DocumentUploadArea } from '../components/document-upload-area.component
 import { DocumentsBatchTagDialog } from '../components/documents-batch-tag-dialog.component';
 import {
   createdAtColumn,
+  documentDateColumn,
   DocumentsPaginatedList,
   standardActionsColumn,
   tagsColumn,
@@ -438,7 +439,7 @@ export const DocumentsPage: Component = () => {
               setRowSelection={setRowSelection}
               getSorting={getSorting}
               setSorting={setSorting}
-              extraColumns={[tagsColumn, createdAtColumn, standardActionsColumn]}
+              extraColumns={[tagsColumn, documentDateColumn, createdAtColumn, standardActionsColumn]}
             />
 
             <DocumentsBatchTagDialog

--- a/apps/papra-client/src/modules/documents/pages/documents.page.tsx
+++ b/apps/papra-client/src/modules/documents/pages/documents.page.tsx
@@ -439,7 +439,12 @@ export const DocumentsPage: Component = () => {
               setRowSelection={setRowSelection}
               getSorting={getSorting}
               setSorting={setSorting}
-              extraColumns={[tagsColumn, documentDateColumn, createdAtColumn, standardActionsColumn]}
+              extraColumns={[
+                tagsColumn,
+                documentDateColumn,
+                createdAtColumn,
+                standardActionsColumn,
+              ]}
             />
 
             <DocumentsBatchTagDialog

--- a/apps/papra-client/src/modules/organizations/pages/organization.page.tsx
+++ b/apps/papra-client/src/modules/organizations/pages/organization.page.tsx
@@ -108,7 +108,12 @@ export const OrganizationPage: Component = () => {
               documentsCount={documentsQuery.data?.documentsCount ?? 0}
               getPagination={getPagination}
               setPagination={setPagination}
-              extraColumns={[tagsColumn, documentDateColumn, createdAtColumn, standardActionsColumn]}
+              extraColumns={[
+                tagsColumn,
+                documentDateColumn,
+                createdAtColumn,
+                standardActionsColumn,
+              ]}
             />
           </>
         )}

--- a/apps/papra-client/src/modules/organizations/pages/organization.page.tsx
+++ b/apps/papra-client/src/modules/organizations/pages/organization.page.tsx
@@ -7,6 +7,7 @@ import { useDocumentUpload } from '@/modules/documents/components/document-impor
 import { DocumentUploadArea } from '@/modules/documents/components/document-upload-area.component';
 import {
   createdAtColumn,
+  documentDateColumn,
   DocumentsPaginatedList,
   standardActionsColumn,
   tagsColumn,
@@ -107,7 +108,7 @@ export const OrganizationPage: Component = () => {
               documentsCount={documentsQuery.data?.documentsCount ?? 0}
               getPagination={getPagination}
               setPagination={setPagination}
-              extraColumns={[tagsColumn, createdAtColumn, standardActionsColumn]}
+              extraColumns={[tagsColumn, documentDateColumn, createdAtColumn, standardActionsColumn]}
             />
           </>
         )}


### PR DESCRIPTION
## Description
This PR addresses issue #1180 by implementing support on the client side to display and sort by the actual document date (`documentDate`) instead of the upload date (`createdAt`).

## Changes
- **Default Sort**: Changed default sorting field from `createdAt` to `documentDate` in the documents constants.
- **Column Definition**: Added `documentDateColumn` in `documents-list.component.tsx` that displays the document's date (formatted relatively) or a fallback dash (`—`) when no date is assigned.
- **Views Integration**: Added the "Date" column to the `extraColumns` array on the main documents page, organization home page, and saved views page.
- **Localization**: Added the translation header key for the new column.

Closes: #1180 


<!-- DO NOT IGNORE THIS MESSAGE

Thank you for you contribution and for taking the time to submit a pull request!

## About vibe-coded contributions

- Please be aware that vibe-coded contribution are **prohibited**.
- We are human behind open source projects, trying hard to maintain and improve them.
- Vibe-coded contributions tend to pollute the codebase and they drain a lot of time and energy from maintainers to review and fix them.
- The maintenance burden created by vibe-coded contributions falls entirely on maintainers.

-> Vibe-coded PRs will be rejected, and repeated offenses may lead to a ban from contributing to our projects.

## About new features or enhancements

- New features or changes should be discussed in an issue before being implemented.
- Discussions help ensure that the proposed changes align with the project's vision and goals, and they allow for feedback and suggestions from the community.
- Please create an issue to discuss your proposed changes before submitting a pull request.
- Also note that an open issue does not mean that the requested feature or change will be accepted or we are willing to have it in the project.

-> Pull requests that introduce un-discussed features or changes may be rejected until the discussion has taken place.

-->
