### PR TITLE
fix(magic-bytes): make mime type detection consistent with file content

### DIFF
--- a/apps/papra-server/src/modules/documents/documents.usecases.ts
+++ b/apps/papra-server/src/modules/documents/documents.usecases.ts
@@ -50,6 +50,7 @@ import {
 import { createDocumentsRepository } from './documents.repository';
 import { extractDocumentText } from './documents.services';
 import { createStorageKey } from './storage/document-storage.usecases';
+import { coerceMimeTypeStream } from '../shared/mime-types/mime-types.usecases';
 
 type DocumentStorageContext = {
   storageKey: string;
@@ -131,18 +132,24 @@ export async function createDocument({
     },
   });
 
+  const { stream: mimeStream, mimeType: inferredMimeType } = await coerceMimeTypeStream({
+    fileStream,
+    fileName,
+    declaredMimeType: mimeType,
+  });
+
   // Create a PassThrough stream that will be used for saving the file
   // This allows us to use pipeline for better error handling
   const outputStream = new PassThrough();
 
-  const streamProcessingPromise = pipeline(fileStream, hashStream, byteCountStream, outputStream);
+  const streamProcessingPromise = pipeline(mimeStream, hashStream, byteCountStream, outputStream);
 
   // We optimistically save the file to leverage streaming, if the file already exists, we will delete it
   const [encryptionMetadata] = await Promise.all([
     documentsStorageService.saveFile({
       fileStream: outputStream,
       storageKey,
-      mimeType,
+      mimeType: inferredMimeType,
       fileName,
     }),
     streamProcessingPromise,
@@ -175,7 +182,7 @@ export async function createDocument({
         newFileStorageContext: { storageKey, ...encryptionMetadata },
         fileName,
         size,
-        mimeType,
+        mimeType: inferredMimeType,
         hash,
         userId,
         organizationId,

--- a/apps/papra-server/src/modules/intake-emails/intake-emails.usecases.ts
+++ b/apps/papra-server/src/modules/intake-emails/intake-emails.usecases.ts
@@ -10,7 +10,6 @@ import type { IntakeEmailUsernameServices } from './username-drivers/intake-emai
 import { safely } from '@corentinth/chisels';
 import { getOrganizationPlan } from '../plans/plans.usecases';
 import { addLogContext, createLogger } from '../shared/logger/logger';
-import { coerceFileMimeType } from '../shared/mime-types/mime-types.usecases';
 import { fileToReadableStream } from '../shared/streams/readable-stream';
 import {
   createIntakeEmailLimitReachedError,
@@ -137,13 +136,11 @@ export async function ingestEmailForRecipient({
 
   await Promise.all(
     attachments.map(async (file) => {
-      const { mimeType } = await coerceFileMimeType({ file });
-
       const [result, error] = await safely(
         createDocument({
           fileStream: fileToReadableStream(file),
           fileName: file.name,
-          mimeType,
+          mimeType: file.type,
           organizationId: intakeEmail.organizationId,
         }),
       );

--- a/apps/papra-server/src/modules/shared/mime-types/mime-types.usecases.test.ts
+++ b/apps/papra-server/src/modules/shared/mime-types/mime-types.usecases.test.ts
@@ -1,59 +1,198 @@
 import { describe, expect, test } from 'vitest';
-import { coerceFileMimeType } from './mime-types.usecases';
+import { coerceMimeTypeStream } from './mime-types.usecases';
+import { Readable } from 'node:stream';
 
 // A PDF file starts with the %PDF magic bytes
 const minimalPdfBytes = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34]);
 
 describe('mime-types usecases', () => {
-  describe('coerceFileMimeType', () => {
-    test('when the file already has a specific (non-octet-stream) mime type, it is preserved as-is', async () => {
-      const file = new File(['hello'], 'document.txt', { type: 'text/plain' });
+  describe('coerceMimeTypeStream', () => {
+    test('returns the original file contents unchanged', async () => {
+      const file = new File([minimalPdfBytes], 'document.pdf', { type: 'application/pdf' });
 
-      const { mimeType } = await coerceFileMimeType({ file });
+      const { stream } = await coerceMimeTypeStream({
+        fileStream: Readable.from(file.stream()),
+        fileName: file.name,
+        declaredMimeType: file.type,
+      });
+
+      expect(
+        Buffer.concat(
+          await (async () => {
+            const chunks: Buffer[] = [];
+            for await (const chunk of stream) {
+              chunks.push(Buffer.from(chunk));
+            }
+            return chunks;
+          })(),
+        ),
+      ).to.eql(Buffer.from(minimalPdfBytes));
+    });
+
+    test('preserves content when input stream emits multiple chunks', async () => {
+      const input = [Buffer.from('hello '), Buffer.from('world')];
+
+      const { stream } = await coerceMimeTypeStream({
+        fileStream: Readable.from(input),
+        fileName: 'file.txt',
+        declaredMimeType: 'text/plain',
+      });
+
+      const content = Buffer.concat(
+        await (async () => {
+          const chunks: Buffer[] = [];
+          for await (const chunk of stream) {
+            chunks.push(Buffer.from(chunk));
+          }
+          return chunks;
+        })(),
+      );
+
+      expect(content.toString()).to.eql('hello world');
+    });
+
+    test('preserves large stream contents', async () => {
+      const chunk = Buffer.alloc(1024 * 1024, 'a');
+
+      const { stream } = await coerceMimeTypeStream({
+        fileStream: Readable.from([chunk, chunk]),
+        fileName: 'large.txt',
+      });
+
+      let size = 0;
+
+      for await (const part of stream) {
+        size += Buffer.from(part).length;
+      }
+
+      expect(size).to.eql(chunk.length * 2);
+    });
+
+    test('returns the full stream even when mime detection fails', async () => {
+      const content = Buffer.from('plain text content');
+
+      const { stream } = await coerceMimeTypeStream({
+        fileStream: Readable.from([content]),
+        fileName: 'file.bin',
+      });
+
+      const output = Buffer.concat(
+        await (async () => {
+          const chunks: Buffer[] = [];
+
+          for await (const chunk of stream) {
+            chunks.push(Buffer.from(chunk));
+          }
+
+          return chunks;
+        })(),
+      );
+
+      expect(output).to.eql(content);
+    });
+
+    test('propagates input stream errors', async () => {
+      const brokenStream = Readable.from(
+        (async function* () {
+          yield Buffer.from('hello');
+          throw new Error('error');
+        })(),
+      );
+
+      const { stream } = await coerceMimeTypeStream({
+        fileStream: brokenStream,
+        fileName: 'file.txt',
+      });
+
+      await expect(async () => {
+        for await (const _ of stream) {
+        }
+      }).rejects.toThrow('error');
+    });
+
+    test('does not modify binary content', async () => {
+      const binary = Buffer.from([0, 255, 1, 128, 50]);
+
+      const { stream } = await coerceMimeTypeStream({
+        fileStream: Readable.from([binary]),
+        fileName: 'file.bin',
+      });
+
+      const output = Buffer.concat(
+        await (async () => {
+          const chunks: Buffer[] = [];
+
+          for await (const chunk of stream) {
+            chunks.push(Buffer.from(chunk));
+          }
+
+          return chunks;
+        })(),
+      );
+
+      expect(output).to.eql(binary);
+    });
+
+    test('detects mime type from magic bytes when available', async () => {
+      const file = new File([minimalPdfBytes], 'document', {
+        type: 'application/octet-stream',
+      });
+
+      const { mimeType } = await coerceMimeTypeStream({
+        fileStream: Readable.from(file.stream()),
+        fileName: file.name,
+        declaredMimeType: file.type,
+      });
+
+      expect(mimeType).to.eql('application/pdf');
+    });
+
+    test('when provided mime type and/or extension mismatch magic bytes, type is inferred by magic bytes', async () => {
+      const file = new File([minimalPdfBytes], 'document.png', {
+        type: 'image/png',
+      });
+
+      const { mimeType } = await coerceMimeTypeStream({
+        fileStream: Readable.from(file.stream()),
+        fileName: file.name,
+        declaredMimeType: file.type,
+      });
+
+      expect(mimeType).to.eql('application/pdf');
+    });
+
+    test('when magic bytes are not available and the file already has a specific (non-octet-stream) mime type, it is preserved as-is', async () => {
+      const file = new File(['hello'], 'document.pdf', { type: 'text/plain' });
+
+      const { mimeType } = await coerceMimeTypeStream({
+        fileStream: Readable.from(file.stream()),
+        fileName: file.name,
+        declaredMimeType: file.type,
+      });
 
       expect(mimeType).to.eql('text/plain');
     });
 
-    test('when the file has application/octet-stream, the mime type is detected from content magic bytes', async () => {
-      const file = new File([minimalPdfBytes], 'document.pdf', {
-        type: 'application/octet-stream',
-      });
-
-      const { mimeType } = await coerceFileMimeType({ file });
-
-      expect(mimeType).to.eql('application/pdf');
-    });
-
-    test('when the file has an empty mime type, the mime type is detected from content magic bytes', async () => {
-      const file = new File([minimalPdfBytes], 'document.pdf', { type: '' });
-
-      const { mimeType } = await coerceFileMimeType({ file });
-
-      expect(mimeType).to.eql('application/pdf');
-    });
-
-    test('when magic bytes detection fails, the mime type is inferred from the file extension', async () => {
+    test('when magic bytes detection fails, and no mime is provided, the mime type is inferred from the file extension', async () => {
       const file = new File(['not-a-real-pdf'], 'report.pdf', { type: 'application/octet-stream' });
 
-      const { mimeType } = await coerceFileMimeType({ file });
+      const { mimeType } = await coerceMimeTypeStream({
+        fileStream: Readable.from(file.stream()),
+        fileName: file.name,
+        declaredMimeType: file.type,
+      });
 
       expect(mimeType).to.eql('application/pdf');
     });
 
-    test('when neither magic bytes nor extension match, application/octet-stream is returned', async () => {
-      const file = new File(['unknown content'], 'file.unknownext', {
-        type: 'application/octet-stream',
-      });
-
-      const { mimeType } = await coerceFileMimeType({ file });
-
-      expect(mimeType).to.eql('application/octet-stream');
-    });
-
-    test('when the file has an empty mime type and no detection matches, application/octet-stream is returned', async () => {
+    test('when no mime type information is available, application/octet-stream is returned', async () => {
       const file = new File(['unknown content'], 'file.unknownext', { type: '' });
 
-      const { mimeType } = await coerceFileMimeType({ file });
+      const { mimeType } = await coerceMimeTypeStream({
+        fileStream: Readable.from(file.stream()),
+        fileName: file.name,
+        declaredMimeType: file.type,
+      });
 
       expect(mimeType).to.eql('application/octet-stream');
     });

--- a/apps/papra-server/src/modules/shared/mime-types/mime-types.usecases.ts
+++ b/apps/papra-server/src/modules/shared/mime-types/mime-types.usecases.ts
@@ -1,21 +1,42 @@
 import { safely } from '@corentinth/chisels';
-import { fileTypeFromBlob } from 'file-type';
-import { isNilOrEmptyString } from '../utils';
+import { fileTypeStream } from 'file-type';
 import { getMimeTypeFromFileName } from './mime-types.models';
+import { Readable } from 'node:stream';
+import { MIME_TYPES } from './mime-types.constants';
 
-export async function coerceFileMimeType({ file }: { file: File }): Promise<{ mimeType: string }> {
-  const declaredMimeType = file.type;
+export async function coerceMimeTypeStream({
+  fileStream,
+  fileName,
+  declaredMimeType,
+}: {
+  fileStream: Readable;
+  fileName: string;
+  declaredMimeType?: string;
+}): Promise<{ stream: Readable; mimeType: string }> {
+  const iterator = fileStream[Symbol.asyncIterator]();
 
-  if (!isNilOrEmptyString(declaredMimeType) && declaredMimeType !== 'application/octet-stream') {
-    return { mimeType: declaredMimeType };
-  }
+  const safeStream = new ReadableStream<Uint8Array>({
+    type: 'bytes',
+    async pull(controller) {
+      const { value, done } = await iterator.next();
+      if (done) {
+        controller.close();
+        return;
+      }
+      controller.enqueue(value instanceof Uint8Array ? new Uint8Array(value) : Buffer.from(value));
+    },
+  });
 
-  const [detected] = await safely(fileTypeFromBlob(file));
-  if (detected) {
-    return { mimeType: detected.mime };
-  }
+  const [detectedStream] = await safely(fileTypeStream(safeStream));
 
-  const extensionMimeType = getMimeTypeFromFileName(file.name);
+  const mimeType =
+    detectedStream?.fileType?.mime ??
+    (declaredMimeType && declaredMimeType !== MIME_TYPES.OCTET_STREAM
+      ? declaredMimeType
+      : getMimeTypeFromFileName(fileName));
 
-  return { mimeType: extensionMimeType };
+  return {
+    stream: detectedStream ? Readable.fromWeb(detectedStream) : fileStream,
+    mimeType,
+  };
 }


### PR DESCRIPTION
Resolves #1126

Previously, documents with missing extensions or incorrect extensions could be assigned the wrong MIME type. This caused incorrect processing pipelines to be selected or fail entirely.

For example, a PDF renamed as `.png` would be treated as an image, causing the image OCR pipeline to run and fail because the content was not actually an image.

# Changes

- Moved MIME type detection into `createDocument`, making it independent from the intake method (web uploads, email intake).
- MIME type detection now works directly on the file stream.
- MIME type resolution priority is now:
  1. Magic bytes
  2. User provided MIME type
  3. File name extension
  4. `application/octet-stream`

Using magic bytes as the primary source makes MIME type detection consistent with the actual file contents.

Added test coverage for:
- preserving stream contents after detection
- multi-chunk streams
- binary streams
- large streams
- stream errors
- MIME type inference precedence