### PR TITLE
refactor(content-extraction): make strategy registry type-safe

### DIFF
--- a/apps/papra-server/src/modules/documents/content-extraction/content-extraction-strategies/content-extraction-strategies.constants.ts
+++ b/apps/papra-server/src/modules/documents/content-extraction/content-extraction-strategies/content-extraction-strategies.constants.ts
@@ -1,0 +1,7 @@
+export const CONTENT_EXTRACTION_STRATEGIES = {
+  internal: 'internal',
+  mistralOcr: 'mistral-ocr',
+} as const;
+
+export const CONTENT_EXTRACTION_STRATEGY_NAMES = Object.values(CONTENT_EXTRACTION_STRATEGIES);
+export type ContentExtractionStrategyName = (typeof CONTENT_EXTRACTION_STRATEGY_NAMES)[number];

--- a/apps/papra-server/src/modules/documents/content-extraction/content-extraction-strategies/content-extraction-strategies.types.ts
+++ b/apps/papra-server/src/modules/documents/content-extraction/content-extraction-strategies/content-extraction-strategies.types.ts
@@ -1,8 +1,13 @@
+import type { Config } from '../../../config/config.types';
+
 export type ContentExtractionStrategy = {
-  name: string;
   canExtractTextFromDocument: (args: { file: File }) => Promise<boolean>;
   extractTextFromDocument: (args: {
     file: File;
     ocrLanguages?: string[];
   }) => Promise<{ text: string; extractionContext?: Record<string, unknown> }>;
 };
+
+export type ContentExtractionStrategyFactory = (args: {
+  config: Config;
+}) => ContentExtractionStrategy;

--- a/apps/papra-server/src/modules/documents/content-extraction/content-extraction-strategies/content-extraction.strategies.ts
+++ b/apps/papra-server/src/modules/documents/content-extraction/content-extraction-strategies/content-extraction.strategies.ts
@@ -1,10 +1,12 @@
+import type { ContentExtractionStrategyName } from './content-extraction-strategies.constants';
+import type { ContentExtractionStrategyFactory } from './content-extraction-strategies.types';
 import { buildLectureContentExtractionStrategy } from './lecture/lecture.content-extraction-strategy';
 import { buildMistralOcrContentExtractionStrategy } from './mistral-ocr/mistral-ocr.content-extraction-strategy';
 
 export const strategiesRegistry = {
   'internal': buildLectureContentExtractionStrategy,
   'mistral-ocr': buildMistralOcrContentExtractionStrategy,
-};
+} satisfies Record<ContentExtractionStrategyName, ContentExtractionStrategyFactory>;
 
 export function getContentExtractionStrategy({ strategyName }: { strategyName: string }) {
   const strategyBuilder = strategiesRegistry[strategyName as keyof typeof strategiesRegistry];

--- a/apps/papra-server/src/modules/documents/content-extraction/content-extraction-strategies/lecture/lecture.content-extraction-strategy.ts
+++ b/apps/papra-server/src/modules/documents/content-extraction/content-extraction-strategies/lecture/lecture.content-extraction-strategy.ts
@@ -3,8 +3,8 @@ import { extractTextFromFile } from '@papra/lecture';
 
 export function buildLectureContentExtractionStrategy(): ContentExtractionStrategy {
   return {
-    name: 'internal',
     canExtractTextFromDocument: async () => true,
+
     extractTextFromDocument: async ({ file, ocrLanguages }) => {
       const { textContent, extractorType } = await extractTextFromFile({
         file,

--- a/apps/papra-server/src/modules/documents/content-extraction/content-extraction-strategies/mistral-ocr/mistral-ocr.content-extraction-strategy.ts
+++ b/apps/papra-server/src/modules/documents/content-extraction/content-extraction-strategies/mistral-ocr/mistral-ocr.content-extraction-strategy.ts
@@ -13,7 +13,6 @@ export function buildMistralOcrContentExtractionStrategy({
   const { baseUrl, apiKey } = config.ai.adapters.mistral;
 
   return {
-    name: 'mistral-ocr',
     canExtractTextFromDocument: async ({ file }) => {
       if (isNilOrEmptyString(apiKey)) {
         return false;
@@ -21,6 +20,7 @@ export function buildMistralOcrContentExtractionStrategy({
 
       return isMistralOcrAbleToExtractTextFromDocument({ file, mimeTypesAllowList });
     },
+
     extractTextFromDocument: async ({ file }) => {
       const { text, processedPagesCount } = await extractTextWithMistralOcr({
         file,

--- a/apps/papra-server/src/modules/documents/content-extraction/content-extraction.config.ts
+++ b/apps/papra-server/src/modules/documents/content-extraction/content-extraction.config.ts
@@ -1,22 +1,26 @@
 import type { AppConfigDefinition } from '../../config/config.types';
 import * as v from 'valibot';
 import { mistralOcrConfig } from './content-extraction-strategies/mistral-ocr/mistral-ocr.content-extraction-strategy.config';
+import {
+  CONTENT_EXTRACTION_STRATEGIES,
+  CONTENT_EXTRACTION_STRATEGY_NAMES,
+} from './content-extraction-strategies/content-extraction-strategies.constants';
 
 export const documentContentExtractionConfig = {
   extractionStrategies: {
     doc: [
-      'Content extraction strategy, it can be a single strategy name like `internal`, or a comma-separated list of strategy names, in order of preference, like `mistral-ocr,internal`. The first strategy that can extract text from the document will be used, and if a strategy fails processing a document, the next one will try. Available strategies are:',
-      '- `internal`: Uses the internal `lecture` library to extract text from documents, which support all common document formats and uses Tesseract for OCR. This strategy is always available, great to use as a fallback when other strategies fail.',
-      '- `mistral-ocr`: Uses the Mistral OCR API to extract text from documents. This strategy requires a valid Mistral API key.',
+      `Content extraction strategy, it can be a single strategy name like \`${CONTENT_EXTRACTION_STRATEGIES.internal}\`, or a comma-separated list of strategy names, in order of preference, like \`${[CONTENT_EXTRACTION_STRATEGIES.mistralOcr, CONTENT_EXTRACTION_STRATEGIES.internal].join(',')}\`. The first strategy that can extract text from the document will be used, and if a strategy fails processing a document, the next one will try. Available strategies are:`,
+      `- \`${CONTENT_EXTRACTION_STRATEGIES.internal}\`: Uses the internal \`lecture\` library to extract text from documents, which support all common document formats and uses Tesseract for OCR. This strategy is always available, great to use as a fallback when other strategies fail.`,
+      `- \`${CONTENT_EXTRACTION_STRATEGIES.mistralOcr}\`: Uses the Mistral OCR API to extract text from documents. This strategy requires a valid Mistral API key.`,
     ].join('\n'),
     schema: v.pipe(
       v.string(),
       v.transform((value) => value.split(',').map((s) => s.trim())),
-      v.array(v.picklist(['internal', 'mistral-ocr'])),
+      v.array(v.picklist(CONTENT_EXTRACTION_STRATEGY_NAMES)),
       v.minLength(1, 'At least one content extraction strategy must be specified.'),
     ),
     env: 'CONTENT_EXTRACTION_STRATEGY',
-    default: 'internal',
+    default: CONTENT_EXTRACTION_STRATEGIES.internal,
     showInDocumentation: false,
   },
   strategy: {


### PR DESCRIPTION
<!-- DO NOT IGNORE THIS MESSAGE

Thank you for you contribution and for taking the time to submit a pull request!

## About vibe-coded contributions

- Please be aware that vibe-coded contribution are **prohibited**.
- We are human behind open source projects, trying hard to maintain and improve them.
- Vibe-coded contributions tend to pollute the codebase and they drain a lot of time and energy from maintainers to review and fix them.
- The maintenance burden created by vibe-coded contributions falls entirely on maintainers.

-> Vibe-coded PRs will be rejected, and repeated offenses may lead to a ban from contributing to our projects.

## About new features or enhancements

- New features or changes should be discussed in an issue before being implemented.
- Discussions help ensure that the proposed changes align with the project's vision and goals, and they allow for feedback and suggestions from the community.
- Please create an issue to discuss your proposed changes before submitting a pull request.
- Also note that an open issue does not mean that the requested feature or change will be accepted or we are willing to have it in the project.

-> Pull requests that introduce un-discussed features or changes may be rejected until the discussion has taken place.

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared set of supported content extraction strategy values, with consistent runtime and type-safe usage across the app.

* **Bug Fixes**
  * Improved content extraction configuration to use the same allowed strategy list for validation, defaults, and displayed options.
  * Kept strategy selection behavior unchanged while tightening type safety and reducing mismatches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->