### PR TITLE
Persist document list pagination across navigation

### DIFF
--- a/apps/papra-client/src/modules/document-views/pages/document-view.page.tsx
+++ b/apps/papra-client/src/modules/document-views/pages/document-view.page.tsx
@@ -16,6 +16,7 @@ import { useI18n } from '@/modules/i18n/i18n.provider';
 import { useConfirmModal } from '@/modules/shared/confirm';
 import { useI18nApiErrors } from '@/modules/shared/http/composables/i18n-api-errors';
 import { createParamSynchronizedPagination } from '@/modules/shared/pagination/query-synchronized-pagination';
+import { buildLocalStorageKey } from '@/modules/shared/signals/persistence/persistence.models';
 import { queryClient } from '@/modules/shared/query/query-client';
 import { Button } from '@/modules/ui/components/button';
 import {
@@ -34,7 +35,9 @@ export const DocumentViewPage: Component = () => {
   const { t } = useI18n();
   const { confirm } = useConfirmModal();
   const { getErrorMessage } = useI18nApiErrors({ t });
-  const [getPagination, setPagination] = createParamSynchronizedPagination();
+  const [getPagination, setPagination] = createParamSynchronizedPagination({
+    localStorageKey: buildLocalStorageKey('document-views', 'pageSize'),
+  });
   const [getIsUpdateOpen, setIsUpdateOpen] = createSignal(false);
 
   const deleteDocumentViewConfirm = async () => {

--- a/apps/papra-client/src/modules/documents/pages/documents.page.tsx
+++ b/apps/papra-client/src/modules/documents/pages/documents.page.tsx
@@ -11,6 +11,7 @@ import { useConfirmModal } from '@/modules/shared/confirm';
 import { createParamSynchronizedPagination } from '@/modules/shared/pagination/query-synchronized-pagination';
 import { queryClient } from '@/modules/shared/query/query-client';
 import { createParamSynchronizedSignal } from '@/modules/shared/signals/params';
+import { buildLocalStorageKey } from '@/modules/shared/signals/persistence/persistence.models';
 import { resolveSetterValue } from '@/modules/shared/signals/setters';
 import { cn } from '@/modules/shared/style/cn';
 import { useDebounce } from '@/modules/shared/utils/timing';
@@ -44,7 +45,9 @@ export const DocumentsPage: Component = () => {
     defaultValue: '',
   });
   const debouncedSearchQuery = useDebounce(getSearchQuery, 300);
-  const [getPagination, setPagination] = createParamSynchronizedPagination();
+  const [getPagination, setPagination] = createParamSynchronizedPagination({
+    localStorageKey: buildLocalStorageKey('documents', 'pageSize'),
+  });
   const [getRowSelection, setRowSelection] = createSignal<RowSelectionState>({});
   const [getSelectAllMatchingQuery, setSelectAllMatchingQuery] = createSignal(false);
   const [getTagDialogOpen, setTagDialogOpen] = createSignal(false);

--- a/apps/papra-client/src/modules/organizations/pages/organization.page.tsx
+++ b/apps/papra-client/src/modules/organizations/pages/organization.page.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/modules/documents/documents.services';
 import { useI18n } from '@/modules/i18n/i18n.provider';
 import { createParamSynchronizedPagination } from '@/modules/shared/pagination/query-synchronized-pagination';
+import { buildLocalStorageKey } from '@/modules/shared/signals/persistence/persistence.models';
 import { Button } from '@/modules/ui/components/button';
 
 export const OrganizationPage: Component = () => {
@@ -26,6 +27,7 @@ export const OrganizationPage: Component = () => {
   const [getPagination, setPagination] = createParamSynchronizedPagination({
     defaultPageSize: 100,
     defaultPageIndex: 0,
+    localStorageKey: buildLocalStorageKey('organizations', 'pageSize'),
   });
 
   const documentsQuery = useQuery(() => ({

--- a/apps/papra-client/src/modules/shared/pagination/query-synchronized-pagination.test.ts
+++ b/apps/papra-client/src/modules/shared/pagination/query-synchronized-pagination.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { createRoot } from 'solid-js';
+import { createParamSynchronizedPagination } from './query-synchronized-pagination';
+
+const searchParamsStore = { page: undefined as string | undefined, pageSize: undefined as string | undefined };
+const setSearchParamsMock = vi.fn((params) => {
+  Object.assign(searchParamsStore, params);
+});
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem(key: string) {
+      return store[key] || null;
+    },
+    setItem(key: string, value: string) {
+      store[key] = value.toString();
+    },
+    clear() {
+      store = {};
+    },
+    removeItem(key: string) {
+      delete store[key];
+    },
+  };
+})();
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock });
+
+vi.mock('@solidjs/router', () => ({
+  useSearchParams: () => [searchParamsStore, setSearchParamsMock],
+}));
+
+describe('createParamSynchronizedPagination', () => {
+  beforeEach(() => {
+    searchParamsStore.page = undefined;
+    searchParamsStore.pageSize = undefined;
+    localStorage.clear();
+    setSearchParamsMock.mockClear();
+  });
+
+  test('should return default values when URL and localStorage are empty', () => {
+    createRoot((dispose) => {
+      const [getPagination] = createParamSynchronizedPagination();
+      expect(getPagination()).toEqual({ pageIndex: 0, pageSize: 15 });
+      dispose();
+    });
+  });
+
+  test('should prioritize URL parameters over localStorage', () => {
+    localStorage.setItem('papra:documents:pageSize', '50');
+    searchParamsStore.pageSize = '100';
+
+    createRoot((dispose) => {
+      const [getPagination] = createParamSynchronizedPagination({
+        localStorageKey: 'papra:documents:pageSize',
+      });
+      expect(getPagination()).toEqual({ pageIndex: 0, pageSize: 100 });
+      dispose();
+    });
+  });
+
+  test('should fallback to localStorage when URL parameter is missing', () => {
+    localStorage.setItem('papra:documents:pageSize', '50');
+
+    createRoot((dispose) => {
+      const [getPagination] = createParamSynchronizedPagination({
+        localStorageKey: 'papra:documents:pageSize',
+      });
+      expect(getPagination()).toEqual({ pageIndex: 0, pageSize: 50 });
+      dispose();
+    });
+  });
+
+  test('should write to localStorage and URL when setPagination is called', () => {
+    createRoot((dispose) => {
+      const [_, setPagination] = createParamSynchronizedPagination({
+        localStorageKey: 'papra:documents:pageSize',
+      });
+
+      setPagination({ pageIndex: 1, pageSize: 50 });
+
+      expect(localStorage.getItem('papra:documents:pageSize')).toBe('50');
+      expect(setSearchParamsMock).toHaveBeenCalledWith(
+        {
+          page: 1,
+          pageSize: 50,
+        },
+        { replace: true }
+      );
+      dispose();
+    });
+  });
+});

--- a/apps/papra-client/src/modules/shared/pagination/query-synchronized-pagination.test.ts
+++ b/apps/papra-client/src/modules/shared/pagination/query-synchronized-pagination.test.ts
@@ -62,6 +62,52 @@ describe('createParamSynchronizedPagination', () => {
   test('should fallback to localStorage when URL parameter is missing', () => {
     localStorage.setItem('papra:documents:pageSize', '50');
 
+    return new Promise<void>((resolve) => {
+      createRoot((dispose) => {
+        const [getPagination] = createParamSynchronizedPagination({
+          localStorageKey: 'papra:documents:pageSize',
+        });
+        expect(getPagination()).toEqual({ pageIndex: 0, pageSize: 50 });
+        
+        setTimeout(() => {
+          // Assert that the effect synchronizes this missing parameter back to the URL
+          expect(setSearchParamsMock).toHaveBeenCalledWith(
+            {
+              pageSize: '50',
+            },
+            { replace: true }
+          );
+          dispose();
+          resolve();
+        }, 0);
+      });
+    });
+  });
+
+  test('should reject invalid values in localStorage and fallback to default', () => {
+    localStorage.setItem('papra:documents:pageSize', '-5');
+    createRoot((dispose) => {
+      const [getPagination] = createParamSynchronizedPagination({
+        localStorageKey: 'papra:documents:pageSize',
+      });
+      expect(getPagination()).toEqual({ pageIndex: 0, pageSize: 15 });
+      dispose();
+    });
+
+    localStorage.setItem('papra:documents:pageSize', 'abc');
+    createRoot((dispose) => {
+      const [getPagination] = createParamSynchronizedPagination({
+        localStorageKey: 'papra:documents:pageSize',
+      });
+      expect(getPagination()).toEqual({ pageIndex: 0, pageSize: 15 });
+      dispose();
+    });
+  });
+
+  test('should reject invalid URL parameters and fallback to localStorage/default', () => {
+    localStorage.setItem('papra:documents:pageSize', '50');
+    searchParamsStore.pageSize = '-100';
+
     createRoot((dispose) => {
       const [getPagination] = createParamSynchronizedPagination({
         localStorageKey: 'papra:documents:pageSize',

--- a/apps/papra-client/src/modules/shared/pagination/query-synchronized-pagination.ts
+++ b/apps/papra-client/src/modules/shared/pagination/query-synchronized-pagination.ts
@@ -20,20 +20,24 @@ export function createParamSynchronizedPagination({
   const [searchParams, setSearchParams] = useSearchParams();
 
   const getPagination: Accessor<Pagination> = () => {
-    const pageIndex = Number(asSingleParam(searchParams[pageIndexParamName]) ?? defaultPageIndex);
+    const urlPageIndex = Number(asSingleParam(searchParams[pageIndexParamName]));
+    const pageIndex =
+      Number.isInteger(urlPageIndex) && urlPageIndex >= 0 ? urlPageIndex : defaultPageIndex;
 
     let initialPageSize = defaultPageSize;
     if (localStorageKey) {
       const stored = localStorage.getItem(localStorageKey);
       if (stored !== null) {
         const parsed = Number(stored);
-        if (!isNaN(parsed)) {
+        if (Number.isInteger(parsed) && parsed > 0) {
           initialPageSize = parsed;
         }
       }
     }
 
-    const pageSize = Number(asSingleParam(searchParams[pageSizeParamName]) ?? initialPageSize);
+    const urlPageSize = Number(asSingleParam(searchParams[pageSizeParamName]));
+    const pageSize =
+      Number.isInteger(urlPageSize) && urlPageSize > 0 ? urlPageSize : initialPageSize;
 
     return { pageIndex, pageSize };
   };

--- a/apps/papra-client/src/modules/shared/pagination/query-synchronized-pagination.ts
+++ b/apps/papra-client/src/modules/shared/pagination/query-synchronized-pagination.ts
@@ -1,4 +1,4 @@
-import type { Accessor, Setter } from 'solid-js';
+import { createEffect, type Accessor, type Setter } from 'solid-js';
 import type { Pagination } from './pagination.types';
 import { useSearchParams } from '@solidjs/router';
 import { resolveSetterValue } from '../signals/setters';
@@ -9,23 +9,41 @@ export function createParamSynchronizedPagination({
   defaultPageSize = 15,
   pageIndexParamName = 'page',
   pageSizeParamName = 'pageSize',
+  localStorageKey,
 }: {
   defaultPageIndex?: number;
   defaultPageSize?: number;
   pageIndexParamName?: string;
   pageSizeParamName?: string;
+  localStorageKey?: string;
 } = {}) {
   const [searchParams, setSearchParams] = useSearchParams();
 
   const getPagination: Accessor<Pagination> = () => {
     const pageIndex = Number(asSingleParam(searchParams[pageIndexParamName]) ?? defaultPageIndex);
-    const pageSize = Number(asSingleParam(searchParams[pageSizeParamName]) ?? defaultPageSize);
+
+    let initialPageSize = defaultPageSize;
+    if (localStorageKey) {
+      const stored = localStorage.getItem(localStorageKey);
+      if (stored !== null) {
+        const parsed = Number(stored);
+        if (!isNaN(parsed)) {
+          initialPageSize = parsed;
+        }
+      }
+    }
+
+    const pageSize = Number(asSingleParam(searchParams[pageSizeParamName]) ?? initialPageSize);
 
     return { pageIndex, pageSize };
   };
 
   const setPagination: Setter<Pagination> = (valueOrUpdater) => {
     const value = resolveSetterValue(valueOrUpdater, getPagination());
+
+    if (localStorageKey) {
+      localStorage.setItem(localStorageKey, String(value.pageSize));
+    }
 
     setSearchParams(
       {
@@ -36,5 +54,29 @@ export function createParamSynchronizedPagination({
     );
   };
 
+  createEffect(() => {
+    const pageIndex = searchParams[pageIndexParamName];
+    const pageSize = searchParams[pageSizeParamName];
+
+    const currentPagination = getPagination();
+    const nextParams: Record<string, string | undefined> = {};
+    let needsUpdate = false;
+
+    if (pageIndex === undefined && currentPagination.pageIndex !== defaultPageIndex) {
+      nextParams[pageIndexParamName] = String(currentPagination.pageIndex);
+      needsUpdate = true;
+    }
+
+    if (pageSize === undefined && currentPagination.pageSize !== defaultPageSize) {
+      nextParams[pageSizeParamName] = String(currentPagination.pageSize);
+      needsUpdate = true;
+    }
+
+    if (needsUpdate) {
+      setSearchParams(nextParams, { replace: true });
+    }
+  });
+
   return [getPagination, setPagination] as const;
 }
+


### PR DESCRIPTION
### Description
Resolves an issue where changing the page limit/pagination preference on the document list was lost when navigating away and returning to the page. 

### Changes
- **Client pagination hook**: Added a `createEffect` to `createParamSynchronizedPagination` that automatically synchronizes active URL parameters with non-default stored page limits/indices from `localStorage` on mount or navigation.
- **Unit tests**: Added a test suite to verify default parameter states, prioritization of URL parameters, and fallback/updating behavior.

Closes: #1085 

<!-- DO NOT IGNORE THIS MESSAGE

Thank you for you contribution and for taking the time to submit a pull request!

## About vibe-coded contributions

- Please be aware that vibe-coded contribution are **prohibited**.
- We are human behind open source projects, trying hard to maintain and improve them.
- Vibe-coded contributions tend to pollute the codebase and they drain a lot of time and energy from maintainers to review and fix them.
- The maintenance burden created by vibe-coded contributions falls entirely on maintainers.

-> Vibe-coded PRs will be rejected, and repeated offenses may lead to a ban from contributing to our projects.

## About new features or enhancements

- New features or changes should be discussed in an issue before being implemented.
- Discussions help ensure that the proposed changes align with the project's vision and goals, and they allow for feedback and suggestions from the community.
- Please create an issue to discuss your proposed changes before submitting a pull request.
- Also note that an open issue does not mean that the requested feature or change will be accepted or we are willing to have it in the project.

-> Pull requests that introduce un-discussed features or changes may be rejected until the discussion has taken place.

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pagination settings (especially page size) are now persisted and kept in sync between the URL and browser storage on key pages, so your preferences carry over when you return.
* **Bug Fixes**
  * Pagination parameter parsing is stricter: invalid values no longer override stored defaults, and missing URL values are automatically filled in.
* **Tests**
  * Added automated coverage for pagination syncing, storage fallback behavior, and URL parameter updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->