### PR TITLE
fix(documents): add creation date as sort fallback

### DIFF
--- a/.changeset/shiny-turkeys-kiss.md
+++ b/.changeset/shiny-turkeys-kiss.md
@@ -1,0 +1,5 @@
+---
+'@papra/app': patch
+---
+
+Document sort order fallback to the importation date when the sort order is set to other sort orders.

--- a/apps/papra-server/src/modules/documents/document-search/database-fts5/database-fts5.repository.models.test.ts
+++ b/apps/papra-server/src/modules/documents/document-search/database-fts5/database-fts5.repository.models.test.ts
@@ -63,38 +63,48 @@ describe('database-fts5 repository models', () => {
       ).to.eql('"documents"."created_at" desc, "documents"."id" desc');
     });
 
-    test('sort by name, the name is sorted case-insensitively', () => {
+    test('sort by name, the name is sorted case-insensitively, with createdAt as fallback', () => {
       expect(
         toOrderByClause(makeSearchOrderByClauses({ sort: { field: 'name', order: 'desc' } })),
-      ).to.eql('"documents"."name" COLLATE NOCASE desc, "documents"."id" desc');
+      ).to.eql(
+        '"documents"."name" COLLATE NOCASE desc, "documents"."created_at" desc, "documents"."id" desc',
+      );
 
       expect(
         toOrderByClause(makeSearchOrderByClauses({ sort: { field: 'name', order: 'asc' } })),
-      ).to.eql('"documents"."name" COLLATE NOCASE asc, "documents"."id" asc');
+      ).to.eql(
+        '"documents"."name" COLLATE NOCASE asc, "documents"."created_at" asc, "documents"."id" asc',
+      );
     });
 
-    test('sort by documentDate asc', () => {
+    test('sort by documentDate asc, with createdAt as fallback', () => {
       expect(
         toOrderByClause(
           makeSearchOrderByClauses({ sort: { field: 'documentDate', order: 'asc' } }),
         ),
-      ).to.eql('"documents"."document_date" asc, "documents"."id" asc');
+      ).to.eql(
+        '"documents"."document_date" asc, "documents"."created_at" asc, "documents"."id" asc',
+      );
 
       expect(
         toOrderByClause(
           makeSearchOrderByClauses({ sort: { field: 'documentDate', order: 'desc' } }),
         ),
-      ).to.eql('"documents"."document_date" desc, "documents"."id" desc');
+      ).to.eql(
+        '"documents"."document_date" desc, "documents"."created_at" desc, "documents"."id" desc',
+      );
     });
 
-    test('sort by updatedAt desc', () => {
+    test('sort by updatedAt desc, with createdAt as fallback', () => {
       expect(
         toOrderByClause(makeSearchOrderByClauses({ sort: { field: 'updatedAt', order: 'desc' } })),
-      ).to.eql('"documents"."updated_at" desc, "documents"."id" desc');
+      ).to.eql(
+        '"documents"."updated_at" desc, "documents"."created_at" desc, "documents"."id" desc',
+      );
 
       expect(
         toOrderByClause(makeSearchOrderByClauses({ sort: { field: 'updatedAt', order: 'asc' } })),
-      ).to.eql('"documents"."updated_at" asc, "documents"."id" asc');
+      ).to.eql('"documents"."updated_at" asc, "documents"."created_at" asc, "documents"."id" asc');
     });
   });
 });

--- a/apps/papra-server/src/modules/documents/document-search/database-fts5/database-fts5.repository.models.ts
+++ b/apps/papra-server/src/modules/documents/document-search/database-fts5/database-fts5.repository.models.ts
@@ -58,6 +58,7 @@ export function makeSearchOrderByClauses({ sort }: { sort: DocumentSearchSort })
 
   const orderByClauses = [
     orderDirection(sortColumn),
+    ...(sort.field !== 'createdAt' ? [orderDirection(documentsTable.createdAt)] : []),
     orderDirection(documentsTable.id), // tie-breaker to ensure deterministic order
   ];
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THIS MESSAGE

Thank you for you contribution and for taking the time to submit a pull request!

## About vibe-coded contributions

- Please be aware that vibe-coded contribution are **prohibited**.
- We are human behind open source projects, trying hard to maintain and improve them.
- Vibe-coded contributions tend to pollute the codebase and they drain a lot of time and energy from maintainers to review and fix them.
- The maintenance burden created by vibe-coded contributions falls entirely on maintainers.

-> Vibe-coded PRs will be rejected, and repeated offenses may lead to a ban from contributing to our projects.

## About new features or enhancements

- New features or changes should be discussed in an issue before being implemented.
- Discussions help ensure that the proposed changes align with the project's vision and goals, and they allow for feedback and suggestions from the community.
- Please create an issue to discuss your proposed changes before submitting a pull request.
- Also note that an open issue does not mean that the requested feature or change will be accepted or we are willing to have it in the project.

-> Pull requests that introduce un-discussed features or changes may be rejected until the discussion has taken place.

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved document list and search sorting for non-primary sort options by adding a consistent secondary fallback to the import date, while keeping stable tie-breaking for deterministic results.
* **Tests**
  * Updated unit tests to reflect the expanded SQL `ORDER BY` fallback behavior across supported sort fields and directions.
* **Chores**
  * Released a patch update and refreshed release documentation for the sorting behavior change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->