### PR TITLE
feat(client): add re-run OCR button in document page

### DIFF
--- a/apps/papra-client/src/locales/en.dictionary.ts
+++ b/apps/papra-client/src/locales/en.dictionary.ts
@@ -422,6 +422,9 @@ export const translations = {
   'documents.actions.cancel': 'Cancel',
   'documents.actions.save': 'Save',
   'documents.actions.saving': 'Saving...',
+  'documents.actions.recalculate-ocr': 'Recalculate OCR',
+  'documents.actions.recalculate-ocr-success': 'OCR recalculation started',
+  'documents.actions.recalculate-ocr-error': 'Failed to start OCR recalculation',
   'documents.content.alert':
     'The content of the document is automatically extracted from the document on upload. It is only used for search and indexing purposes.',
   'documents.content.empty-placeholder':

--- a/apps/papra-client/src/locales/fr.dictionary.ts
+++ b/apps/papra-client/src/locales/fr.dictionary.ts
@@ -420,6 +420,9 @@ export const translations: Partial<TranslationsDictionary> = {
   'documents.actions.cancel': 'Annuler',
   'documents.actions.save': 'Enregistrer',
   'documents.actions.saving': 'Enregistrement...',
+  'documents.actions.recalculate-ocr': 'Recalculer OCR',
+  'documents.actions.recalculate-ocr-success': 'Recalcul OCR lancé',
+  'documents.actions.recalculate-ocr-error': 'Échec du recalcul OCR',
   'documents.content.alert':
     "Le contenu du document est automatiquement extrait du document lors de l'import. Il est uniquement utilisé pour la recherche et l'indexation.",
   'documents.content.empty-placeholder':

--- a/apps/papra-client/src/modules/documents/components/document-content-edition-panel.component.tsx
+++ b/apps/papra-client/src/modules/documents/components/document-content-edition-panel.component.tsx
@@ -48,9 +48,6 @@ export const DocumentContentEditionPanel: Component<{
       }),
     onSuccess: () => {
       createToast({ type: 'success', message: t('documents.actions.recalculate-ocr-success') });
-      void queryClient.invalidateQueries({
-        queryKey: ['organizations', props.organizationId, 'documents', props.documentId],
-      });
     },
     onError: () => {
       createToast({ type: 'error', message: t('documents.actions.recalculate-ocr-error') });
@@ -90,6 +87,7 @@ export const DocumentContentEditionPanel: Component<{
           variant="outline"
           onClick={() => reprocessMutation.mutate()}
           isLoading={reprocessMutation.isPending}
+          disabled={isEditing()}
         >
           {t('documents.actions.recalculate-ocr')}
         </Button>

--- a/apps/papra-client/src/modules/documents/components/document-content-edition-panel.component.tsx
+++ b/apps/papra-client/src/modules/documents/components/document-content-edition-panel.component.tsx
@@ -8,7 +8,7 @@ import { Button } from '@/modules/ui/components/button';
 import { createToast } from '@/modules/ui/components/sonner';
 import { TextArea } from '@/modules/ui/components/textarea';
 import { TextFieldRoot } from '@/modules/ui/components/textfield';
-import { updateDocument } from '../documents.services';
+import { reprocessDocument, updateDocument } from '../documents.services';
 
 export const DocumentContentEditionPanel: Component<{
   documentId: string;
@@ -37,6 +37,23 @@ export const DocumentContentEditionPanel: Component<{
     },
     onError: () => {
       createToast({ type: 'error', message: 'Failed to update document content' });
+    },
+  }));
+
+  const reprocessMutation = useMutation(() => ({
+    mutationFn: async () =>
+      reprocessDocument({
+        documentId: props.documentId,
+        organizationId: props.organizationId,
+      }),
+    onSuccess: () => {
+      createToast({ type: 'success', message: t('documents.actions.recalculate-ocr-success') });
+      void queryClient.invalidateQueries({
+        queryKey: ['organizations', props.organizationId, 'documents', props.documentId],
+      });
+    },
+    onError: () => {
+      createToast({ type: 'error', message: t('documents.actions.recalculate-ocr-error') });
     },
   }));
 
@@ -69,6 +86,13 @@ export const DocumentContentEditionPanel: Component<{
         />
       </TextFieldRoot>
       <div class="flex justify-end gap-2">
+        <Button
+          variant="outline"
+          onClick={() => reprocessMutation.mutate()}
+          isLoading={reprocessMutation.isPending}
+        >
+          {t('documents.actions.recalculate-ocr')}
+        </Button>
         <Show
           when={isEditing()}
           fallback={

--- a/apps/papra-client/src/modules/documents/documents.services.ts
+++ b/apps/papra-client/src/modules/documents/documents.services.ts
@@ -236,3 +236,16 @@ export async function fetchDocumentActivities({
     activities: activities.map(coerceDates),
   };
 }
+
+export async function reprocessDocument({
+  documentId,
+  organizationId,
+}: {
+  documentId: string;
+  organizationId: string;
+}) {
+  await apiClient({
+    method: 'POST',
+    path: `/api/organizations/${organizationId}/documents/${documentId}/reprocess`,
+  });
+}

--- a/apps/papra-server/src/modules/documents/documents.routes.ts
+++ b/apps/papra-server/src/modules/documents/documents.routes.ts
@@ -56,6 +56,7 @@ export function registerDocumentsRoutes(context: RouteDefinitionContext) {
   setupDeleteDocumentRoute(context);
   setupGetDocumentFileRoute(context);
   setupUpdateDocumentRoute(context);
+  setupReprocessDocumentRoute(context);
 }
 
 function setupCreateDocumentRoute({ app, ...deps }: RouteDefinitionContext) {
@@ -482,6 +483,45 @@ function setupDeleteAllTrashDocumentsRoute({
       });
 
       return context.body(null, 204);
+    },
+  );
+}
+
+function setupReprocessDocumentRoute({
+  app,
+  db,
+  config,
+  taskServices,
+}: RouteDefinitionContext) {
+  app.post(
+    '/api/organizations/:organizationId/documents/:documentId/reprocess',
+    requireAuthentication({ apiKeyPermissions: ['documents:update'] }),
+    validateParams(
+      v.strictObject({
+        organizationId: organizationIdSchema,
+        documentId: documentIdSchema,
+      }),
+    ),
+    async (context) => {
+      const { userId } = getUser({ context });
+      const { organizationId, documentId } = context.req.valid('param');
+
+      const documentsRepository = createDocumentsRepository({ db });
+      const organizationsRepository = createOrganizationsRepository({ db });
+
+      await ensureUserIsInOrganization({ userId, organizationId, organizationsRepository });
+      await ensureDocumentExists({ documentId, organizationId, documentsRepository });
+
+      await taskServices.scheduleJob({
+        taskName: 'extract-document-file-content',
+        data: {
+          documentId,
+          organizationId,
+          ocrLanguages: config.documents.ocrLanguages,
+        },
+      });
+
+      return context.json({ success: true });
     },
   );
 }


### PR DESCRIPTION
issue #933 

With the arrival of Mistral OCR, I wanted to re-run some OCR task on already-imported documents.
So I added a "Recalculate OCR" in the content tab

<img width="1215" height="828" alt="image" src="https://github.com/user-attachments/assets/2d44434c-6ac6-4d5a-8bd4-42012d0687ec" />

For now it is only this button, but it can be extended in the `/documents` tab to do bulk re-run

Let me know if there are any issues I can fix !

## Modifications (client) :
### `document-content-edition-panel.component.tsx` : 
Added new mutation `reprocessMutation` to handle the button (success and error)

### `documents.services.ts`:
New `reprocessDocument` service which calls (POST) `/api/organizations/${organizationId}/documents/${documentId}/reprocess`

### locale files (french & english)
Create new string : 
```
documents.actions.recalculate-ocr
documents.actions.recalculate-ocr-success
documents.actions.recalculate-ocr-error
```

## Modifications (server) :
### `documents.routes.ts`:
Create new route which schedule job `extract-document-file-content`

