### PR TITLE
fix(ingestion): retry on transient EIO errors when ingesting doc(x) files

### DIFF
--- a/apps/papra-server/src/modules/ingestion-folders/ingestion-folder.models.ts
+++ b/apps/papra-server/src/modules/ingestion-folders/ingestion-folder.models.ts
@@ -9,13 +9,14 @@ export function normalizeFilePathToIngestionFolder({
   filePath: string;
   ingestionFolderPath: string;
 }) {
-  const relativeFilePath = relative(ingestionFolderPath, filePath);
+  const relativeFilePath = relative(ingestionFolderPath, filePath).replace(/\\/g, '/');
 
   return { relativeFilePath };
 }
 
 export function getOrganizationIdFromFilePath({ relativeFilePath }: { relativeFilePath: string }) {
-  const [maybeOrganizationId] = relativeFilePath.split(pathSeparator);
+  const normalized = relativeFilePath.replace(/\\/g, '/');
+  const [maybeOrganizationId] = normalized.split('/');
 
   if (isNil(maybeOrganizationId) || !ORGANIZATION_ID_REGEX.test(maybeOrganizationId)) {
     return { organizationId: undefined };
@@ -44,7 +45,8 @@ export function getAbsolutePathFromFolderRelativeToOrganizationIngestionFolder({
   path: string;
   organizationIngestionFolderPath: string;
 }) {
-  return isAbsolute(path) ? path : join(organizationIngestionFolderPath, path);
+  const result = isAbsolute(path) ? path : join(organizationIngestionFolderPath, path);
+  return result.replace(/\\/g, '/');
 }
 
 export function isFileInErrorFolder({
@@ -61,7 +63,7 @@ export function isFileInErrorFolder({
     organizationIngestionFolderPath,
   });
 
-  return filePath.startsWith(errorFolderPath);
+  return filePath.replace(/\\/g, '/').startsWith(errorFolderPath);
 }
 
 export function isFileInDoneFolder({
@@ -78,5 +80,5 @@ export function isFileInDoneFolder({
     organizationIngestionFolderPath,
   });
 
-  return filePath.startsWith(doneFolderPath);
+  return filePath.replace(/\\/g, '/').startsWith(doneFolderPath);
 }

--- a/apps/papra-server/src/modules/ingestion-folders/ingestion-folders.constants.ts
+++ b/apps/papra-server/src/modules/ingestion-folders/ingestion-folders.constants.ts
@@ -5,6 +5,12 @@ export const defaultIgnoredPatterns = [
   '**/desktop.ini',
   '**/Thumbs.db',
 
+  // Microsoft Office temporary/lock files
+  '**/~$*',
+
+  // LibreOffice lock files
+  '**/.~lock.*#',
+
   // Directories
   '**/.git/**',
   '**/.idea/**',

--- a/apps/papra-server/src/modules/ingestion-folders/ingestion-folders.usecases.test.ts
+++ b/apps/papra-server/src/modules/ingestion-folders/ingestion-folders.usecases.test.ts
@@ -637,6 +637,76 @@ describe('ingestion-folders usecases', () => {
           },
         ]);
       });
+
+      test('if a transient retryable error (e.g., EIO) occurs, the file ingestion is retried and succeeds if the error resolves', async () => {
+        const taskServices = createInMemoryTaskServices();
+        const { logger } = createTestLogger();
+
+        const { db } = await createInMemoryDatabase({
+          organizations: [{ id: 'org_111111111111111111111111', name: 'Org 1' }],
+        });
+        const organizationsRepository = createOrganizationsRepository({ db });
+
+        const config = overrideConfig({
+          ingestionFolder: {
+            folderRootPath: '/apps/papra/ingestion',
+            postProcessing: {
+              strategy: 'delete',
+            },
+          },
+          documentsStorage: {
+            driver: 'in-memory',
+          },
+        });
+
+        const documentsStorageService = createInMemoryDocumentStorageServices();
+        const generateDocumentId = () => 'doc_1';
+
+        const { fs, getFsState } = createInMemoryFsServices({
+          '/apps/papra/ingestion/org_111111111111111111111111/hello.md': 'lorem ipsum',
+        });
+
+        let attempts = 0;
+        const createDocumentMock = createDocumentCreationUsecase({
+          db,
+          config,
+          logger,
+          documentsStorageService,
+          generateDocumentId,
+          taskServices,
+          eventServices: createTestEventServices(),
+        });
+
+        await processFile({
+          filePath: '/apps/papra/ingestion/org_111111111111111111111111/hello.md',
+          ingestionFolderPath: '/apps/papra/ingestion',
+          config,
+          organizationsRepository,
+          logger,
+          fs,
+          createDocument: async (args) => {
+            attempts++;
+            if (attempts < 3) {
+              const err = new Error('EIO: i/o error, read');
+              (err as any).code = 'EIO';
+              throw err;
+            }
+            return createDocumentMock(args);
+          },
+        });
+
+        // Ensure it succeeded eventually
+        expect(attempts).to.equal(3);
+
+        const documents = await db.select().from(documentsTable);
+        expect(documents).to.have.length(1);
+        expect(documents[0]?.id).to.equal('doc_1');
+
+        // Since post processing strategy is delete, the file should be deleted on success
+        expect(getFsState()).to.deep.equal({
+          '/apps/papra/ingestion/org_111111111111111111111111': null,
+        });
+      });
     });
   });
 

--- a/apps/papra-server/src/modules/ingestion-folders/ingestion-folders.usecases.ts
+++ b/apps/papra-server/src/modules/ingestion-folders/ingestion-folders.usecases.ts
@@ -153,16 +153,6 @@ export async function processFile({
     errorFolder,
   } = config.ingestionFolder;
 
-  // Get the file from the ingestion folder as a File Instance
-  const [getFileResult, getFileError] = safelySync(() => getFile({ filePath, fs }));
-
-  if (getFileError) {
-    logger.error({ filePath, error: getFileError }, 'Error reading file');
-    return;
-  }
-
-  const { fileStream, mimeType, fileName } = getFileResult;
-
   const { organizationId } = await getFileOrganizationId({
     filePath,
     ingestionFolderPath,
@@ -189,31 +179,110 @@ export async function processFile({
     return;
   }
 
-  // TODO: switch to native stream
-  const [result, error] = await safely(
-    createDocument({
-      fileStream,
-      fileName,
-      mimeType,
-      organizationId,
-    }),
-  );
+  let result;
+  let error: any;
+  let isReadFileError = false;
+  const maxAttempts = 5;
+  let attempt = 0;
+
+  while (attempt < maxAttempts) {
+    attempt++;
+    const [getFileResult, getFileError] = safelySync(() => getFile({ filePath, fs }));
+
+    if (getFileError) {
+      error = getFileError;
+      isReadFileError = true;
+      const isRetryable =
+        getFileError.code === 'EIO' ||
+        getFileError.code === 'EBUSY' ||
+        getFileError.code === 'ENOENT' ||
+        getFileError.message?.includes('EIO') ||
+        getFileError.message?.includes('EBUSY');
+
+      if (isRetryable && attempt < maxAttempts) {
+        logger.warn(
+          { filePath, error: getFileError, attempt },
+          'Error reading file from ingestion folder, retrying...',
+        );
+        await new Promise((resolve) => setTimeout(resolve, 1000 * attempt));
+        continue;
+      }
+      break;
+    }
+
+    isReadFileError = false;
+    const { fileStream, mimeType, fileName } = getFileResult;
+
+    // TODO: switch to native stream
+    const [createResult, createError] = await safely(
+      createDocument({
+        fileStream,
+        fileName,
+        mimeType,
+        organizationId,
+      }),
+    );
+
+    result = createResult;
+    error = createError;
+
+    if (error) {
+      const isNotInsertedBecauseAlreadyExists = isErrorWithCode({
+        error,
+        code: DOCUMENT_ALREADY_EXISTS_ERROR_CODE,
+      });
+
+      if (isNotInsertedBecauseAlreadyExists) {
+        break;
+      }
+
+      const isRetryable =
+        error.code === 'EIO' ||
+        error.code === 'EBUSY' ||
+        error.code === 'ENOENT' ||
+        error.message?.includes('EIO') ||
+        error.message?.includes('EBUSY');
+
+      if (isRetryable && attempt < maxAttempts) {
+        logger.warn(
+          { filePath, error, attempt },
+          'Error creating document from ingestion folder (retryable), retrying...',
+        );
+        await new Promise((resolve) => setTimeout(resolve, 1000 * attempt));
+        continue;
+      }
+    }
+
+    break;
+  }
+
+  if (error) {
+    if (isReadFileError) {
+      logger.error({ filePath, error }, 'Error reading file');
+      return;
+    }
+
+    const isNotInsertedBecauseAlreadyExists = isErrorWithCode({
+      error,
+      code: DOCUMENT_ALREADY_EXISTS_ERROR_CODE,
+    });
+
+    if (!isNotInsertedBecauseAlreadyExists) {
+      logger.error({ filePath, error }, 'Error creating document');
+      const errorFolderPath = getAbsolutePathFromFolderRelativeToOrganizationIngestionFolder({
+        path: errorFolder,
+        organizationIngestionFolderPath,
+      });
+
+      await moveIngestionFile({ filePath, moveToFolder: errorFolderPath, fs });
+      return;
+    }
+  }
 
   const isNotInsertedBecauseAlreadyExists = isErrorWithCode({
     error,
     code: DOCUMENT_ALREADY_EXISTS_ERROR_CODE,
   });
-
-  if (error && !isNotInsertedBecauseAlreadyExists) {
-    logger.error({ filePath, error }, 'Error creating document');
-    const errorFolderPath = getAbsolutePathFromFolderRelativeToOrganizationIngestionFolder({
-      path: errorFolder,
-      organizationIngestionFolderPath,
-    });
-
-    await moveIngestionFile({ filePath, moveToFolder: errorFolderPath, fs });
-    return;
-  }
 
   if (isNotInsertedBecauseAlreadyExists) {
     logger.info({ filePath }, 'Document not inserted because it already exists');


### PR DESCRIPTION
### Description
Resolves the issue where uploading `.doc` and `.docx` files via the ingestion folder failed with an `EIO: i/o error, read` when the file was still locked or being written by the transferring client (like Samba/SMB or NFS mounts).

### Changes
- **Retry Mechanism**: Added a retry loop (5 attempts with backoff) in the folder ingestion watcher to wait for OS write/locks to clear.
- **Ignore Temp Files**: Added Microsoft Office (`~$*`) and LibreOffice (`.~lock.*#`) lock files to the default ignore list.
- **Path Normalization**: Normalized backslashes to forward slashes to ensure post-processing folder matching works correctly on Windows.

Closes: #1376 

<!-- DO NOT IGNORE THIS MESSAGE

Thank you for you contribution and for taking the time to submit a pull request!

## About vibe-coded contributions

- Please be aware that vibe-coded contribution are **prohibited**.
- We are human behind open source projects, trying hard to maintain and improve them.
- Vibe-coded contributions tend to pollute the codebase and they drain a lot of time and energy from maintainers to review and fix them.
- The maintenance burden created by vibe-coded contributions falls entirely on maintainers.

-> Vibe-coded PRs will be rejected, and repeated offenses may lead to a ban from contributing to our projects.

## About new features or enhancements

- New features or changes should be discussed in an issue before being implemented.
- Discussions help ensure that the proposed changes align with the project's vision and goals, and they allow for feedback and suggestions from the community.
- Please create an issue to discuss your proposed changes before submitting a pull request.
- Also note that an open issue does not mean that the requested feature or change will be accepted or we are willing to have it in the project.

-> Pull requests that introduce un-discussed features or changes may be rejected until the discussion has taken place.

-->
