### PR TITLE
fix(docs): typecheck config import without server emit

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -12,11 +12,12 @@
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "astro sync && tsc --noEmit"
   },
   "dependencies": {
     "@astrojs/solid-js": "^7.0.0",
     "@astrojs/starlight": "^0.41.1",
+    "@papra/app-server": "workspace:*",
     "@valibot/to-json-schema": "^1.6.0",
     "astro": "catalog:",
     "sharp": "catalog:",

--- a/apps/docs/src/config.data.ts
+++ b/apps/docs/src/config.data.ts
@@ -1,6 +1,6 @@
 import type { ConfigDefinition, ConfigDefinitionElement } from 'figue';
 
-import { configDefinition } from '../../papra-server/src/modules/config/config';
+import { configDefinition } from '@papra/app-server/config';
 import { renderMarkdown } from './markdown';
 
 function walk(

--- a/apps/docs/src/env.d.ts
+++ b/apps/docs/src/env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="astro/client" />
+
+declare module '*?raw' {
+  const content: string;
+  export default content;
+}

--- a/apps/docs/src/pages/papra-config-schema.json.ts
+++ b/apps/docs/src/pages/papra-config-schema.json.ts
@@ -2,7 +2,7 @@ import type { APIRoute } from 'astro';
 import type { ConfigDefinition } from 'figue';
 import { toJsonSchema } from '@valibot/to-json-schema';
 import * as v from 'valibot';
-import { configDefinition } from '../../../papra-server/src/modules/config/config';
+import { configDefinition } from '@papra/app-server/config';
 
 function buildConfigSchema({
   configDefinition,

--- a/apps/docs/src/shims/app-server-config.ts
+++ b/apps/docs/src/shims/app-server-config.ts
@@ -1,0 +1,10 @@
+import type { ConfigDefinition } from 'figue';
+
+/**
+ * Type-check stand-in for `@papra/app-server/config`.
+ *
+ * Astro/Vite resolves the real package export at build time. Mapping this shim
+ * in `tsconfig.json` keeps `tsc --noEmit` from pulling the server module graph
+ * into the docs project (see #87).
+ */
+export const configDefinition = {} as ConfigDefinition;

--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -1,5 +1,10 @@
 {
   "extends": "astro/tsconfigs/strict",
+  "compilerOptions": {
+    "paths": {
+      "@papra/app-server/config": ["./src/shims/app-server-config.ts"]
+    }
+  },
   "include": [".astro/types.d.ts", "**/*"],
   "exclude": ["dist"]
 }

--- a/apps/papra-server/package.json
+++ b/apps/papra-server/package.json
@@ -11,7 +11,8 @@
     "./organizations/constants": "./src/modules/organizations/organizations.constants.ts",
     "./customProperties/constants": "./src/modules/custom-properties/custom-properties.constants.ts",
     "./apiKeys/constants": "./src/modules/api-keys/api-keys.constants.ts",
-    "./plans/constants": "./src/modules/plans/plans.constants.ts"
+    "./plans/constants": "./src/modules/plans/plans.constants.ts",
+    "./config": "./src/modules/config/config.ts"
   },
   "scripts": {
     "dev": "tsx watch --env-file-if-exists=.env  src/index.ts | crowlog-pretty",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       '@astrojs/starlight':
         specifier: ^0.41.1
         version: 0.41.1(@astrojs/markdown-remark@7.2.0)(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@azure/storage-blob@12.27.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.1)(idb-keyval@6.2.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(typescript@6.0.3)
+      '@papra/app-server':
+        specifier: workspace:*
+        version: link:../papra-server
       '@valibot/to-json-schema':
         specifier: ^1.6.0
         version: 1.6.0(valibot@1.3.1(typescript@6.0.3))
@@ -336,7 +339,7 @@ importers:
         version: 8.21.3(solid-js@1.9.13)
       better-auth:
         specifier: 'catalog:'
-        version: 1.6.11(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.14.0)(kysely@0.28.17))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(solid-js@1.9.13)(vitest@4.1.9(@types/node@26.0.1)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 1.6.11(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.14.0)(kysely@0.28.17))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(solid-js@1.9.13)(vitest@4.1.9)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -493,7 +496,7 @@ importers:
         version: 1.6.0(valibot@1.3.1(typescript@6.0.3))
       better-auth:
         specifier: 'catalog:'
-        version: 1.6.11(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.14.0)(kysely@0.28.17))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(solid-js@1.9.13)(vitest@4.1.9(@types/node@26.0.1)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 1.6.11(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.14.0)(kysely@0.28.17))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(solid-js@1.9.13)(vitest@4.1.9)
       busboy:
         specifier: ^1.6.0
         version: 1.6.0
@@ -16291,36 +16294,6 @@ snapshots:
       drizzle-orm: 0.45.2(@libsql/client@0.14.0)(kysely@0.28.17)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
-      solid-js: 1.9.13
-      vitest: 4.1.9(@types/node@26.0.1)(@vitest/coverage-v8@4.0.3)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
-    transitivePeerDependencies:
-      - '@cloudflare/workers-types'
-      - '@opentelemetry/api'
-
-  better-auth@1.6.11(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.14.0)(kysely@0.28.17))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(solid-js@1.9.13)(vitest@4.1.9(@types/node@26.0.1)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))):
-    dependencies:
-      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
-      '@better-auth/drizzle-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@libsql/client@0.14.0)(kysely@0.28.17))
-      '@better-auth/kysely-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.17)
-      '@better-auth/memory-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
-      '@better-auth/mongo-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
-      '@better-auth/prisma-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
-      '@better-auth/telemetry': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)
-      '@better-auth/utils': 0.4.0
-      '@better-fetch/fetch': 1.1.21
-      '@noble/ciphers': 2.2.0
-      '@noble/hashes': 2.0.1
-      better-call: 1.3.5(zod@4.4.3)
-      defu: 6.1.4
-      jose: 6.2.3
-      kysely: 0.28.17
-      nanostores: 1.3.0
-      zod: 4.4.3
-    optionalDependencies:
-      drizzle-kit: 0.31.10
-      drizzle-orm: 0.45.2(@libsql/client@0.14.0)(kysely@0.28.17)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
       solid-js: 1.9.13
       vitest: 4.1.9(@types/node@26.0.1)(@vitest/coverage-v8@4.0.3)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary
- Replaces the relative `../../papra-server/...` import with `@papra/app-server/config`, matching the existing package-export pattern used by the client
- Adds a tsc-only shim + `tsconfig` path mapping so `tsc --noEmit` does **not** pull the server module graph into docs (no emit/build step)
- Runs `astro sync` before typecheck and adds Vite `?raw` / Astro client typings

This is meant as the simpler alternative to #145 (which needed declaration emit).

Closes #87

## Test plan
- [x] `pnpm -F @papra/docs typecheck` passes locally
- [ ] Docs site still builds and config docs / schema endpoint resolve real server config at build time
- [ ] CI green

Made with [Cursor](https://cursor.com)