### PR TITLE
chore(docker): HEALTHCHECK for /api/health

### DIFF
--- a/apps/papra-server/Dockerfile
+++ b/apps/papra-server/Dockerfile
@@ -56,5 +56,9 @@ COPY pnpm-workspace.yaml ./
 
 EXPOSE 1221
 
+# Hits /api/health (node is already in the image — no curl/jq needed)
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD node -e "fetch('http://127.0.0.1:'+(process.env.PORT||1221)+'/api/health').then(async r=>{const j=await r.json();process.exit(j.status==='ok'?0:1)}).catch(()=>process.exit(1))"
+
 # The command is overridden by Fly at runtime, see ./fly.toml
 CMD [ "pnpm", "--silent", "start:with-migrations" ]

--- a/packages/app/Dockerfile
+++ b/packages/app/Dockerfile
@@ -58,4 +58,7 @@ ENV BETTER_AUTH_TELEMETRY=0
 
 RUN mkdir -p ./app-data/db ./app-data/documents ./ingestion
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD node -e "fetch('http://127.0.0.1:'+(process.env.PORT||1221)+'/api/health').then(async r=>{const j=await r.json();process.exit(j.status==='ok'?0:1)}).catch(()=>process.exit(1))"
+
 CMD ["pnpm", "start:with-migrations"]

--- a/packages/app/Dockerfile.rootless
+++ b/packages/app/Dockerfile.rootless
@@ -67,4 +67,7 @@ ENV CLIENT_BASE_URL=http://localhost:1221
 # Disable Better Auth telemetry
 ENV BETTER_AUTH_TELEMETRY=0
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD node -e "fetch('http://127.0.0.1:'+(process.env.PORT||1221)+'/api/health').then(async r=>{const j=await r.json();process.exit(j.status==='ok'?0:1)}).catch(()=>process.exit(1))"
+
 CMD ["pnpm", "start:with-migrations"]


### PR DESCRIPTION
## Why
Handy for Docker/K8s/etc. to know the process is up and the DB check is green.

## What
Added `HEALTHCHECK` to:
- `apps/papra-server/Dockerfile`
- `packages/app/Dockerfile`
- `packages/app/Dockerfile.rootless`

Uses node `fetch` against `/api/health` and exits 0 when `status === 'ok'`. Avoids needing curl/jq in the slim images.

Relates to #691

## Test plan
- [ ] build one of the images and run it
- [ ] `docker inspect` shows Health.Status healthy after start-period