### PR TITLE
Fix: Allow re-inviting removed users to organizations

### DIFF
--- a/apps/papra-server/src/modules/organizations/organizations.repository.ts
+++ b/apps/papra-server/src/modules/organizations/organizations.repository.ts
@@ -411,6 +411,16 @@ async function saveOrganizationInvitation({
       status: ORGANIZATION_INVITATION_STATUS.PENDING,
       expiresAt: addDays(now, expirationDelayDays),
     })
+    .onConflictDoUpdate({
+      target: [organizationInvitationsTable.organizationId, organizationInvitationsTable.email],
+      set: {
+        role,
+        inviterId,
+        status: ORGANIZATION_INVITATION_STATUS.PENDING,
+        expiresAt: addDays(now, expirationDelayDays),
+        updatedAt: now,
+      },
+    })
     .returning();
 
   return { organizationInvitation };

--- a/apps/papra-server/src/modules/organizations/organizations.usecases.test.ts
+++ b/apps/papra-server/src/modules/organizations/organizations.usecases.test.ts
@@ -769,6 +769,68 @@ describe('organizations usecases', () => {
       ]);
     });
 
+    test('can invite a member if an invitation already exists but its status is not pending', async () => {
+      const { logger } = createTestLogger();
+      const { db } = await createInMemoryDatabase({
+        users: [{ id: 'user-1', email: 'owner@example.com' }],
+        organizations: [{ id: 'organization-1', name: 'Organization 1' }],
+        organizationMembers: [
+          { organizationId: 'organization-1', userId: 'user-1', role: ORGANIZATION_ROLES.OWNER },
+        ],
+        organizationInvitations: [
+          {
+            id: 'invitation-1',
+            organizationId: 'organization-1',
+            email: 'invited@example.com',
+            role: ORGANIZATION_ROLES.MEMBER,
+            inviterId: 'user-1',
+            status: 'accepted',
+            expiresAt: new Date('2025-12-31'),
+          },
+        ],
+      });
+
+      const organizationsRepository = createOrganizationsRepository({ db });
+      const subscriptionsRepository = createSubscriptionsRepository({ db });
+      const config = overrideConfig({
+        organizations: { invitationExpirationDelayDays: 7, maxUserInvitationsPerDay: 10 },
+      });
+      const plansRepository = {
+        getOrganizationPlanById: async () => ({
+          organizationPlan: {
+            limits: {
+              maxOrganizationsMembersCount: 100,
+            },
+          },
+        }),
+      } as unknown as PlansRepository;
+
+      const emailsServices = {
+        sendEmail: async () => {},
+      } as unknown as EmailsServices;
+
+      const result = await inviteMemberToOrganization({
+        email: 'invited@example.com',
+        role: ORGANIZATION_ROLES.MEMBER,
+        organizationId: 'organization-1',
+        organizationsRepository,
+        subscriptionsRepository,
+        plansRepository,
+        planEntitlementsRepository: createPlanEntitlementsRepository({ db }),
+        planEntitlementDefinitionRegistry: createPlanEntitlementDefinitionRegistry({ config }),
+        inviterId: 'user-1',
+        expirationDelayDays: 7,
+        maxInvitationsPerDay: 10,
+        logger,
+        emailsServices,
+        config,
+      });
+
+      assert(result.organizationInvitation);
+      expect(result.organizationInvitation.email).toBe('invited@example.com');
+      expect(result.organizationInvitation.status).toBe('pending');
+    });
+
     test('cannot invite new members when the organization has reached its maximum member count (including pending invitations) defined by the plan to enforce subscription limits', async () => {
       const { logger, getLogs } = createTestLogger();
       const { db } = await createInMemoryDatabase({

--- a/apps/papra-server/src/modules/organizations/organizations.usecases.ts
+++ b/apps/papra-server/src/modules/organizations/organizations.usecases.ts
@@ -302,7 +302,7 @@ export async function inviteMemberToOrganization({
     organizationId,
   });
 
-  if (invitation) {
+  if (invitation && invitation.status === ORGANIZATION_INVITATION_STATUS.PENDING) {
     logger.error(
       { inviterId, organizationId, email, invitationId: invitation.id },
       'Invitation already exists',


### PR DESCRIPTION
### Summary:

This PR resolves a bug where users who were previously members of an organization cannot be re-invited due to a combination of:
1. The use case blocking invitations for any pre-existing record (regardless of status).
2. The SQLite database schema `UNIQUE(organization_id, email)` constraint throwing an error when attempting to insert a new invitation.

To fix this, updated:
- The invitation check to only block if there is a `PENDING` invitation.
- The `saveOrganizationInvitation` query to use `.onConflictDoUpdate` to reset and update the existing non-pending invitation record.

Closes: #1398
<!-- DO NOT IGNORE THIS MESSAGE

Thank you for you contribution and for taking the time to submit a pull request!

## About vibe-coded contributions

- Please be aware that vibe-coded contribution are **prohibited**.
- We are human behind open source projects, trying hard to maintain and improve them.
- Vibe-coded contributions tend to pollute the codebase and they drain a lot of time and energy from maintainers to review and fix them.
- The maintenance burden created by vibe-coded contributions falls entirely on maintainers.

-> Vibe-coded PRs will be rejected, and repeated offenses may lead to a ban from contributing to our projects.

## About new features or enhancements

- New features or changes should be discussed in an issue before being implemented.
- Discussions help ensure that the proposed changes align with the project's vision and goals, and they allow for feedback and suggestions from the community.
- Please create an issue to discuss your proposed changes before submitting a pull request.
- Also note that an open issue does not mean that the requested feature or change will be accepted or we are willing to have it in the project.

-> Pull requests that introduce un-discussed features or changes may be rejected until the discussion has taken place.

-->
