### PR TITLE
chore(docker): add HEALTHCHECK against /api/health

### DIFF
--- a/apps/papra-server/Dockerfile
+++ b/apps/papra-server/Dockerfile
@@ -56,5 +56,9 @@ COPY pnpm-workspace.yaml ./
 
 EXPOSE 1221
 
+# Validate /api/health (node is in the image; avoids curl/jq on slim)
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD node -e "fetch('http://127.0.0.1:'+(process.env.PORT||1221)+'/api/health').then(async r=>{if(!r.ok)process.exit(1);const j=await r.json();process.exit(j.status==='ok'?0:1)}).catch(()=>process.exit(1))"
+
 # The command is overridden by Fly at runtime, see ./fly.toml
 CMD [ "pnpm", "--silent", "start:with-migrations" ]

--- a/packages/app/Dockerfile
+++ b/packages/app/Dockerfile
@@ -58,4 +58,8 @@ ENV BETTER_AUTH_TELEMETRY=0
 
 RUN mkdir -p ./app-data/db ./app-data/documents ./ingestion
 
+# Validate /api/health (node is in the image; avoids curl/jq on slim)
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD node -e "fetch('http://127.0.0.1:'+(process.env.PORT||1221)+'/api/health').then(async r=>{if(!r.ok)process.exit(1);const j=await r.json();process.exit(j.status==='ok'?0:1)}).catch(()=>process.exit(1))"
+
 CMD ["pnpm", "start:with-migrations"]

--- a/packages/app/Dockerfile.rootless
+++ b/packages/app/Dockerfile.rootless
@@ -67,4 +67,8 @@ ENV CLIENT_BASE_URL=http://localhost:1221
 # Disable Better Auth telemetry
 ENV BETTER_AUTH_TELEMETRY=0
 
+# Validate /api/health (node is in the image; avoids curl/jq on slim)
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD node -e "fetch('http://127.0.0.1:'+(process.env.PORT||1221)+'/api/health').then(async r=>{if(!r.ok)process.exit(1);const j=await r.json();process.exit(j.status==='ok'?0:1)}).catch(()=>process.exit(1))"
+
 CMD ["pnpm", "start:with-migrations"]


### PR DESCRIPTION
## Summary
- Adds `HEALTHCHECK` to `apps/papra-server/Dockerfile`, `packages/app/Dockerfile`, and `packages/app/Dockerfile.rootless`
- Hits `/api/health` with Node `fetch` (already in the image — no `curl`/`jq` needed on slim)
- Exits non-zero when the request fails, returns non-2xx, or `status !== \"ok\"` (covers the 500 DB-unhealthy path)

Closes #691

## Why this approach
Maintainer note on the issue suggested `curl -f`, but these images are `node:*-slim` and do not include curl by default. Node 18+ `fetch` keeps the images unchanged.

## Test plan
- [ ] `docker build` one of the Dockerfiles
- [ ] Run the container and confirm `docker inspect` → `State.Health.Status` becomes `healthy` after start-period
- [ ] Break DB / stop the process and confirm health flips to `unhealthy`


Made with [Cursor](https://cursor.com)