### PR TITLE
fix: random WebKitBlobResource error 1 in browser when displaying doc…

### DIFF
--- a/apps/papra-client/src/modules/documents/pages/document-pdf-viewer.page.tsx
+++ b/apps/papra-client/src/modules/documents/pages/document-pdf-viewer.page.tsx
@@ -1,7 +1,7 @@
 import type { Component } from 'solid-js';
 import { A, useParams } from '@solidjs/router';
 import { useQuery } from '@tanstack/solid-query';
-import { lazy, onCleanup, Show, Suspense } from 'solid-js';
+import { createMemo, lazy, onCleanup, Show, Suspense } from 'solid-js';
 import { useI18n } from '@/modules/i18n/i18n.provider';
 import { Button } from '@/modules/ui/components/button';
 import { fetchDocument, fetchDocumentFile } from '../documents.services';
@@ -35,8 +35,12 @@ export const DocumentPdfViewerPage: Component = () => {
     return document ? pdfMimeTypes.includes(document.mimeType) : false;
   };
 
-  const getDataUrl = () =>
-    documentFileQuery.data ? URL.createObjectURL(documentFileQuery.data) : undefined;
+  const getDataUrl = createMemo<string | undefined>((prev) => {
+    if (prev) {
+      URL.revokeObjectURL(prev);
+    }
+    return documentFileQuery.data ? URL.createObjectURL(documentFileQuery.data) : undefined;
+  });
 
   onCleanup(() => {
     const dataUrl = getDataUrl();

--- a/gold-donkeys-roll.md
+++ b/gold-donkeys-roll.md
@@ -1,0 +1,5 @@
+---
+'@papra/app': patch
+---
+
+Fix PDF content preview rendering issue after navigation


### PR DESCRIPTION
With `getDataUrl` being a plain function, every reactive read (e.g. `<Show when={getDataUrl()}>`) called `URL.createObjectURL()` again, producing a fresh blob URL each time. The blob URL passed to pdfjs was then effectively orphaned on subsequent re-renders, and Safari's pdfjs fetches could hit a stale/revoked URL mid-load, producing the WebKitBlobResource error 1. Memoizing the function addresses this issue and is consistent with `document-preview.component.tsx`

Solves #1413