### PR TITLE
fix(documents): reset global selection on row change

### DIFF
--- a/.changeset/hungry-planets-smell.md
+++ b/.changeset/hungry-planets-smell.md
@@ -1,0 +1,5 @@
+---
+'@papra/app': patch
+---
+
+Fixed the batch document selection remaining in "select all matching documents" mode after unselecting documents.

--- a/apps/papra-client/src/modules/documents/pages/documents.page.tsx
+++ b/apps/papra-client/src/modules/documents/pages/documents.page.tsx
@@ -45,7 +45,7 @@ export const DocumentsPage: Component = () => {
   });
   const debouncedSearchQuery = useDebounce(getSearchQuery, 300);
   const [getPagination, setPagination] = createParamSynchronizedPagination();
-  const [getRowSelection, setRowSelection] = createSignal<RowSelectionState>({});
+  const [getRowSelection, setInternalRowSelection] = createSignal<RowSelectionState>({});
   const [getSelectAllMatchingQuery, setSelectAllMatchingQuery] = createSignal(false);
   const [getTagDialogOpen, setTagDialogOpen] = createSignal(false);
 
@@ -101,6 +101,11 @@ export const DocumentsPage: Component = () => {
       }),
     placeholderData: keepPreviousData,
   }));
+
+  const setRowSelection: Setter<RowSelectionState> = (valueOrUpdater) => {
+    setSelectAllMatchingQuery(false);
+    return setInternalRowSelection(valueOrUpdater);
+  };
 
   const getSelectedIds = createMemo(() => {
     const selection = getRowSelection();


### PR DESCRIPTION
## Summary

Fix the batch selection state remaining in "select all matching documents" mode after manually changing the row selection.

When all matching documents were selected, deselecting a document on the current page updated the table selection but kept the global selection flag enabled. As a result, the UI continued to display that all documents were selected and kept batch actions targeting the entire query.

The row selection setter now clears the global selection flag before applying the table selection update.

The existing pagination behavior remains unchanged.

## Testing

- Select all documents on the current page
- Click "Select all X documents"
- Deselect one document without changing the page
- Confirm that the global selection message disappears
- Confirm that the selected count reflects the remaining explicitly selected documents

Also verified with:

- Client typecheck
- Lint and formatting checks

Fixes #1417