### PR TITLE
feat(client): enhance mobile display on narrow screens

### DIFF
--- a/apps/papra-client/src/locales/en.dictionary.ts
+++ b/apps/papra-client/src/locales/en.dictionary.ts
@@ -769,6 +769,7 @@ export const translations = {
   'tags.table.headers.tag': 'Tag',
   'tags.table.headers.description': 'Description',
   'tags.table.headers.documents': 'Documents',
+  'tags.table.mobile.documents-count': '{{ count }} Document{{ plural }}',
   'tags.table.headers.created': 'Created',
   'tags.table.headers.actions': 'Actions',
   'tags.picker.search-placeholder': 'Search tags...',

--- a/apps/papra-client/src/modules/documents/components/documents-list.component.tsx
+++ b/apps/papra-client/src/modules/documents/components/documents-list.component.tsx
@@ -124,7 +124,9 @@ export const deletedAtColumn: ColumnDef<Document> = {
 export const standardActionsColumn: ColumnDef<Document> = {
   header: () => {
     const { t } = useI18n();
-    return <span class="block text-right">{t('documents.list.table.headers.actions')}</span>;
+    return (
+      <span class="hidden text-right sm:block">{t('documents.list.table.headers.actions')}</span>
+    );
   },
   id: 'actions',
   enableSorting: false,
@@ -143,14 +145,16 @@ export const tagsColumn: ColumnDef<Document> = {
   accessorKey: 'tags',
   enableSorting: false,
   cell: (data) => (
-    <DocumentTagsList
-      tags={data.getValue<Tag[]>()}
-      tagClass="text-xs text-muted-foreground"
-      triggerClass="size-6"
-      documentId={data.row.original.id}
-      organizationId={data.row.original.organizationId}
-      asLink
-    />
+    <div class="hidden sm:block">
+      <DocumentTagsList
+        tags={data.getValue<Tag[]>()}
+        tagClass="text-xs text-muted-foreground"
+        triggerClass="size-6"
+        documentId={data.row.original.id}
+        organizationId={data.row.original.organizationId}
+        asLink
+      />
+    </div>
   ),
 };
 
@@ -167,7 +171,12 @@ export const DocumentsPaginatedList: Component<{
   getSorting?: Accessor<SortingState>;
   setSorting?: Setter<SortingState>;
 }> = (props) => {
-  const { t } = useI18n();
+  const { t, formatDate } = useI18n();
+  const isHiddenOnMobileColumn = (columnId: string) =>
+    columnId === 'documentDate' || columnId === 'createdAt' || columnId === 'tags' || columnId === 'deletedAt';
+  const isActionColumn = (columnId: string) => columnId === 'actions';
+  const isNameColumn = (columnId: string) => columnId === 'name';
+
   const table = createSolidTable({
     get data() {
       return props.documents ?? [];
@@ -181,17 +190,17 @@ export const DocumentsPaginatedList: Component<{
         accessorFn: (row) => row.name,
         enableSorting: true,
         cell: (data) => (
-          <div class="overflow-hidden flex gap-4 items-center max-w-500px">
+          <div class="overflow-hidden flex gap-4 items-center w-full min-w-0 sm:max-w-500px">
             <div class="bg-muted flex items-center justify-center p-2 rounded-lg">
               <div
                 class={cn(getDocumentIcon({ document: data.row.original }), 'size-6 text-primary')}
               />
             </div>
 
-            <div class="flex-1 flex flex-col gap-1 truncate">
+            <div class="flex-1 min-w-0 flex flex-col gap-1">
               <A
                 href={`/organizations/${data.row.original.organizationId}/documents/${data.row.original.id}`}
-                class="font-bold truncate block hover:underline"
+                class="font-bold block max-w-full truncate hover:underline"
                 title={data.row.original.name}
               >
                 {getDocumentNameWithoutExtension({
@@ -205,8 +214,25 @@ export const DocumentsPaginatedList: Component<{
                   getDocumentNameExtension({ name: data.row.original.name }),
                 ]
                   .filter(Boolean)
-                  .join(' - ')}{' '}
-                - <RelativeTime date={data.row.original.createdAt} />
+                  .join(' - ')}
+                <Show when={data.row.original.documentDate}>
+                  {(documentDate) => <> {' - '}{formatDate(documentDate(), { dateStyle: 'short' })}</>}
+                </Show>
+              </div>
+
+              <div class="text-xs text-muted-foreground/80 sm:hidden">
+                {t('documents.list.table.headers.created')} <RelativeTime date={data.row.original.createdAt} />
+              </div>
+
+              <div class="sm:hidden mt-1">
+                <DocumentTagsList
+                  tags={data.row.original.tags}
+                  tagClass="text-xs text-muted-foreground"
+                  triggerClass="size-6"
+                  documentId={data.row.original.id}
+                  organizationId={data.row.original.organizationId}
+                  asLink
+                />
               </div>
             </div>
           </div>
@@ -251,7 +277,13 @@ export const DocumentsPaginatedList: Component<{
                     <For each={headerGroup.headers}>
                       {(header) => {
                         return (
-                          <TableHead>
+                          <TableHead
+                            class={cn(
+                              isHiddenOnMobileColumn(header.column.id) && 'hidden sm:table-cell',
+                              isActionColumn(header.column.id) &&
+                                'w-9 px-1 sm:w-auto sm:px-2',
+                            )}
+                          >
                             <Show when={!header.isPlaceholder}>
                               <Show
                                 when={header.column.getCanSort()}
@@ -294,7 +326,14 @@ export const DocumentsPaginatedList: Component<{
                     <TableRow data-state={row.getIsSelected() && 'selected'}>
                       <For each={row.getVisibleCells()}>
                         {(cell) => (
-                          <TableCell>
+                          <TableCell
+                            class={cn(
+                              isHiddenOnMobileColumn(cell.column.id) && 'hidden sm:table-cell',
+                              isNameColumn(cell.column.id) && 'w-full min-w-0 max-w-0',
+                              isActionColumn(cell.column.id) &&
+                                'w-9 px-1 sm:w-auto sm:px-2',
+                            )}
+                          >
                             {flexRender(cell.column.columnDef.cell, cell.getContext())}
                           </TableCell>
                         )}

--- a/apps/papra-client/src/modules/documents/pages/document.page.tsx
+++ b/apps/papra-client/src/modules/documents/pages/document.page.tsx
@@ -264,10 +264,15 @@ const DocumentOpenWithDropdown: Component<{ document: Document; organizationId: 
       <DropdownMenu>
         <DropdownMenuTrigger
           as={(triggerProps: DropdownMenuTriggerProps) => (
-            <Button variant="outline" size="sm" {...triggerProps}>
-              <div class="i-tabler-app-window size-4 mr-2" />
-              {t('documents.open-with.label')}
-              <div class="i-tabler-chevron-down size-3 ml-1" />
+            <Button
+              variant="outline"
+              size="sm"
+              {...triggerProps}
+              aria-label={t('documents.open-with.label')} 
+            >
+              <div class="i-tabler-app-window size-4 sm:mr-2" />
+              <span class="hidden sm:inline">{t('documents.open-with.label')}</span>
+              <div class="i-tabler-chevron-down size-3 sm:ml-1" />
             </Button>
           )}
         />
@@ -398,9 +403,10 @@ export const DocumentPage: Component = () => {
                       }
                       variant="outline"
                       size="sm"
+                      aria-label={t('documents.actions.download.title')}
                     >
-                      <div class="i-tabler-download size-4 mr-2" />
-                      {t('documents.actions.download.title')}
+                      <div class="i-tabler-download size-4 sm:mr-2" />
+                      <span class="hidden sm:inline">{t('documents.actions.download.title')}</span>
                     </Button>
 
                     <DocumentOpenWithDropdown
@@ -418,9 +424,10 @@ export const DocumentPage: Component = () => {
                       }
                       variant="outline"
                       size="sm"
+                      aria-label={t('document-share-links.share-action')}
                     >
-                      <div class="i-tabler-share size-4 mr-2" />
-                      {t('document-share-links.share-action')}
+                      <div class="i-tabler-share size-4 sm:mr-2" />
+                      <span class="hidden sm:inline">{t('document-share-links.share-action')}</span>
                     </Button>
 
                     {getDocument().isDeleted ? (
@@ -429,14 +436,19 @@ export const DocumentPage: Component = () => {
                         size="sm"
                         onClick={async () => restore({ document: getDocument() })}
                         isLoading={getIsRestoring()}
+                        aria-label={t('documents.actions.restore')}
                       >
-                        <div class="i-tabler-refresh size-4 mr-2" />
-                        {t('documents.actions.restore')}
+                        <div class="i-tabler-refresh size-4 sm:mr-2" />
+                        <span class="hidden sm:inline">{t('documents.actions.restore')}</span>
                       </Button>
                     ) : (
-                      <Button variant="destructive" size="sm" onClick={deleteDoc}>
-                        <div class="i-tabler-trash size-4 mr-2" />
-                        {t('documents.actions.delete')}
+                      <Button variant="destructive" 
+                        size="sm" 
+                        onClick={deleteDoc} 
+                        aria-label={t('documents.actions.delete')}
+                      >
+                        <div class="i-tabler-trash size-4 sm:mr-2" />
+                        <span class="hidden sm:inline">{t('documents.actions.delete')}</span>
                       </Button>
                     )}
                   </div>

--- a/apps/papra-client/src/modules/tags/pages/tags.page.tsx
+++ b/apps/papra-client/src/modules/tags/pages/tags.page.tsx
@@ -322,6 +322,8 @@ export const TagsPage: Component = () => {
   const { confirm } = useConfirmModal();
   const { t } = useI18n();
   const { getErrorMessage } = useI18nApiErrors({ t });
+  const isHiddenOnMobileColumn = (columnId: string) =>
+    columnId === 'description' || columnId === 'documentsCount' || columnId === 'createdAt';
 
   const query = useQuery(() => ({
     queryKey: ['organizations', params.organizationId, 'tags'],
@@ -382,7 +384,17 @@ export const TagsPage: Component = () => {
         header: () => t('tags.table.headers.tag'),
         accessorKey: 'name',
         sortingFn: 'alphanumeric',
-        cell: (data) => <TagLink {...data.row.original} />,
+        cell: (data) => (
+          <div class="min-w-0">
+            <TagLink {...data.row.original} />
+            <div class="text-xs text-muted-foreground mt-1 sm:hidden truncate">
+              {`${t('tags.table.mobile.documents-count', {
+                count: data.row.original.documentsCount,
+                plural: data.row.original.documentsCount === 1 ? '' : 's',
+              })} - ${data.row.original.description || t('tags.form.no-description')}`}
+            </div>
+          </div>
+        ),
       },
       {
         header: () => t('tags.table.headers.description'),
@@ -503,7 +515,9 @@ export const TagsPage: Component = () => {
                       <TableRow>
                         <For each={headerGroup.headers}>
                           {(header) => (
-                            <TableHead>
+                            <TableHead
+                              class={isHiddenOnMobileColumn(header.column.id) ? 'hidden sm:table-cell' : ''}
+                            >
                               <Show
                                 when={header.column.getCanSort()}
                                 fallback={flexRender(
@@ -540,7 +554,9 @@ export const TagsPage: Component = () => {
                       <TableRow>
                         <For each={row.getVisibleCells()}>
                           {(cell) => (
-                            <TableCell>
+                            <TableCell
+                              class={isHiddenOnMobileColumn(cell.column.id) ? 'hidden sm:table-cell' : ''}
+                            >
                               {flexRender(cell.column.columnDef.cell, cell.getContext())}
                             </TableCell>
                           )}


### PR DESCRIPTION
Documents and tags page are now restricted to narrow screen width with rearranged metadata display.

This is achieved by hiding blocks as I don't think it is possible just using a grid system and breakpoints.

## Documents

- Tags are displayed on their own line
- Dates are arranged with document date after file type and creation date below.
- Title is truncated with ellipsis "…" if needed

<img width="1170" height="529" alt="image" src="https://github.com/user-attachments/assets/6dc331a4-85be-4a46-9ba6-c6381046a443" />

<img width="393" height="852" alt="image" src="https://github.com/user-attachments/assets/5e887709-3b6e-4bed-ae11-6b088e6f6911" />

## Tags

- Description and count is displayed below tag name
- "Created" info is removed

<img width="907" height="529" alt="image" src="https://github.com/user-attachments/assets/1c306c49-7889-45e8-9d77-95f702a3ca78" />

<img width="381" height="529" alt="image" src="https://github.com/user-attachments/assets/54d7bfb8-3b9f-489e-8f5a-a8e475b66eb6" />

## Document view

- Reduce action icons to their icons only

<img width="1167" height="652" alt="image" src="https://github.com/user-attachments/assets/3bd9bd46-56a5-40e4-9495-106739ea9ab2" />

<img width="383" height="652" alt="image" src="https://github.com/user-attachments/assets/2c20fda0-8606-4ce8-8cd2-2e942cfbb2b4" />

Fixes #1421 