### PR TITLE
feat(search-parser): add support for custom operators

### DIFF
--- a/.changeset/eighty-jokes-smile.md
+++ b/.changeset/eighty-jokes-smile.md
@@ -1,0 +1,14 @@
+---
+'@papra/search-parser': minor
+---
+
+Added support for custom filter operators. Pass `operators` to `parseSearchQuery` to replace the built-in `>`, `<`, `>=`, `<=` and `=` set with your own, for instance to add a `~` "contains" operator:
+
+```typescript
+parseSearchQuery({ query: 'name:~invoice', operators: [...DEFAULT_OPERATORS, '~'] });
+// { expression: { type: 'filter', field: 'name', operator: '~', value: 'invoice' }, issues: [] }
+```
+
+The operator type is inferred from the operators you declare, so `expression.operator` stays narrowed instead of widening to `string`. The longest matching operator always wins, and operators that cannot be tokenized (containing whitespace, parentheses or quotes) are ignored and reported as `invalid-operator` issues. `defaultOperator` controls what a filter without an explicit operator (`tag:invoice`) means; it defaults to `=`, and becomes required when `=` is not part of the declared operators.
+
+The AST types now take an optional operator type argument that defaults to the built-in `Operator` union, so existing usage is unaffected.

--- a/.changeset/eighty-jokes-smile.md
+++ b/.changeset/eighty-jokes-smile.md
@@ -9,6 +9,6 @@ parseSearchQuery({ query: 'name:~invoice', operators: [...DEFAULT_OPERATORS, '~'
 // { expression: { type: 'filter', field: 'name', operator: '~', value: 'invoice' }, issues: [] }
 ```
 
-The operator type is inferred from the operators you declare, so `expression.operator` stays narrowed instead of widening to `string`. The longest matching operator always wins, and operators that cannot be tokenized (containing whitespace, parentheses or quotes) are ignored and reported as `invalid-operator` issues. `defaultOperator` controls what a filter without an explicit operator (`tag:invoice`) means; it defaults to `=`, and becomes required when `=` is not part of the declared operators.
+The operator type is inferred from the operators you declare, so `expression.operator` stays narrowed instead of widening to `string`. The longest matching operator always wins, and operators that cannot be tokenized (containing whitespace, parentheses or quotes) are ignored and reported as `invalid-operator` issues. `defaultOperator` controls what a filter without an explicit operator (`tag:invoice`) means; it defaults to `=`, and becomes required when `=` is not part of the declared operators. Only declared operators ever reach the AST: a default operator that was not declared, or that was itself rejected, is reported and replaced by a declared one.
 
 The AST types now take an optional operator type argument that defaults to the built-in `Operator` union, so existing usage is unaffected.

--- a/packages/search-parser/README.md
+++ b/packages/search-parser/README.md
@@ -105,7 +105,7 @@ A few things worth knowing:
 - The longest matching operator always wins, so `~=` takes precedence over `~` no matter the order you declare them in.
 - Operators only apply right after the colon: `name:~invoice`, not `name~invoice`.
 - Operators cannot contain whitespace, parentheses or quotes, as those characters delimit tokens. Invalid operators are ignored and reported as `invalid-operator` issues rather than throwing.
-- When a filter has no explicit operator (`tag:invoice`), `defaultOperator` is used. It defaults to `=` and must be one of the declared operators, so that the inferred operator type never lies about what the parser can return. Dropping `=` from the operator set therefore makes `defaultOperator` required. This is also enforced at runtime, for untyped consumers: a default operator that was not declared, or that was itself rejected, is reported as an `invalid-operator` issue and replaced by a declared one, so only declared operators ever reach the AST.
+- When a filter has no explicit operator (`tag:invoice`), `defaultOperator` is used. It defaults to `=` and must be one of the declared operators, so that the inferred operator type never lies about what the parser can return. Dropping `=` from the operator set therefore makes `defaultOperator` required. This is also enforced at runtime, for untyped consumers: a default operator that was not declared, or that was itself rejected, is reported as an `invalid-operator` issue and replaced by a declared one, so only declared operators ever reach the AST. The single exception is an operator set in which every entry was rejected, as no declared operator is then left to fall back to: the built-in `=` is used, and reported.
 
 ```typescript
 // `tag:invoice` is treated as `tag:~invoice`

--- a/packages/search-parser/README.md
+++ b/packages/search-parser/README.md
@@ -68,9 +68,11 @@ my invoice
 ### Filters
 
 ```
-tag:invoice                # Equality (same as tag:=invoice)
+tag:invoice                # No explicit operator, uses the default one (same as tag:=invoice)
 createdAt:>2024-01-01      # Comparison operators: >, <, >=, <=, =
 ```
+
+A filter without an explicit operator means equality, unless you change `defaultOperator`. Both the operator set and that default are configurable, see [Custom Operators](#custom-operators).
 
 ### Logical Operators
 

--- a/packages/search-parser/README.md
+++ b/packages/search-parser/README.md
@@ -105,7 +105,7 @@ A few things worth knowing:
 - The longest matching operator always wins, so `~=` takes precedence over `~` no matter the order you declare them in.
 - Operators only apply right after the colon: `name:~invoice`, not `name~invoice`.
 - Operators cannot contain whitespace, parentheses or quotes, as those characters delimit tokens. Invalid operators are ignored and reported as `invalid-operator` issues rather than throwing.
-- When a filter has no explicit operator (`tag:invoice`), `defaultOperator` is used. It defaults to `=` and must be one of the declared operators, so that the inferred operator type never lies about what the parser can return. Dropping `=` from the operator set therefore makes `defaultOperator` required.
+- When a filter has no explicit operator (`tag:invoice`), `defaultOperator` is used. It defaults to `=` and must be one of the declared operators, so that the inferred operator type never lies about what the parser can return. Dropping `=` from the operator set therefore makes `defaultOperator` required. This is also enforced at runtime, for untyped consumers: a default operator that was not declared, or that was itself rejected, is reported as an `invalid-operator` issue and replaced by a declared one, so only declared operators ever reach the AST.
 
 ```typescript
 // `tag:invoice` is treated as `tag:~invoice`

--- a/packages/search-parser/README.md
+++ b/packages/search-parser/README.md
@@ -9,6 +9,7 @@ You can play with the parser in the [demo application](https://search-parser.pap
 - **Dependency-free**: No external dependencies, lightweight and fast.
 - **Error-resilient**: Best-effort parsing with detailed issue reporting.
 - **Rich syntax support**: Logical operators (AND, OR, NOT), grouping with parentheses, and field-based filters.
+- **Custom operators**: Bring your own filter operators (e.g. `~` for "contains") on top of the built-in ones.
 - **Configurable limits**: Control maximum depth and token count to prevent abuse.
 - **Optimization**: Simplifies the parsed expression tree by removing redundancies, and basic boolean algebra simplifications.
 
@@ -86,6 +87,32 @@ NOT tag:personal
 (tag:invoice OR tag:receipt) AND status:active
 ```
 
+### Custom Operators
+
+The built-in operators are `>`, `<`, `>=`, `<=` and `=`. Pass `operators` to replace that set with your own, for instance to add a `~` "contains" operator:
+
+```typescript
+const operators = ['>=', '<=', '>', '<', '=', '~'] as const;
+
+parseSearchQuery({ query: 'name:~invoice', operators });
+// { expression: { type: 'filter', field: 'name', operator: '~', value: 'invoice' }, issues: [] }
+```
+
+The operator type is inferred from what you pass, so `expression.operator` is narrowed to `'>=' | '<=' | '>' | '<' | '=' | '~'` rather than widened to `string`.
+
+A few things worth knowing:
+
+- The longest matching operator always wins, so `~=` takes precedence over `~` no matter the order you declare them in.
+- Operators only apply right after the colon: `name:~invoice`, not `name~invoice`.
+- Operators cannot contain whitespace, parentheses or quotes, as those characters delimit tokens. Invalid operators are ignored and reported as `invalid-operator` issues rather than throwing.
+- When a filter has no explicit operator (`tag:invoice`), `defaultOperator` is used. It defaults to `=` and must be one of the declared operators, so that the inferred operator type never lies about what the parser can return. Dropping `=` from the operator set therefore makes `defaultOperator` required.
+
+```typescript
+// `tag:invoice` is treated as `tag:~invoice`
+parseSearchQuery({ query: 'tag:invoice', operators: ['=', '~'], defaultOperator: '~' });
+// { expression: { type: 'filter', field: 'tag', operator: '~', value: 'invoice' }, issues: [] }
+```
+
 ### Optimization
 
 You can enable optimization to simplify the parsed expression tree:
@@ -141,17 +168,35 @@ parseSearchQuery({ query, optimize: true });
 ## API
 
 ```typescript
-function parseSearchQuery(options: {
-  query: string;
-  maxDepth?: number; // Default: 10
-  maxTokens?: number; // Default: 200
-  optimize?: boolean; // Default: true
-}): ParsedQuery;
+function parseSearchQuery<const TOperator extends string = Operator>(
+  options: {
+    query: string;
+    maxDepth?: number; // Default: 10
+    maxTokens?: number; // Default: 200
+    optimize?: boolean; // Default: true
+  } & ('=' extends TOperator
+    ? // Default: ['>=', '<=', '>', '<', '='] and '='
+      { operators?: readonly TOperator[]; defaultOperator?: NoInfer<TOperator> }
+    : // `=` is not a declared operator, so there is no sound default to fall back to
+      { operators: readonly TOperator[]; defaultOperator: NoInfer<TOperator> }),
+): ParsedQuery<TOperator>;
 
-type ParsedQuery = {
-  expression: Expression;
+type ParsedQuery<TOperator extends string = Operator> = {
+  expression: Expression<TOperator>;
   issues: Issue[];
 };
+
+type Operator = '>' | '<' | '>=' | '<=' | '=';
+```
+
+The AST types (`Expression`, `FilterExpression`, `AndExpression`, ...) all take an optional operator type argument that defaults to the built-in `Operator` union, so they can be used without a type argument when you stick to the built-in operators.
+
+The built-in defaults are also exported, to extend them rather than restate them:
+
+```typescript
+import { DEFAULT_OPERATOR, DEFAULT_OPERATORS } from '@papra/search-parser';
+
+parseSearchQuery({ query: 'name:~invoice', operators: [...DEFAULT_OPERATORS, '~'] });
 ```
 
 ## Error Handling

--- a/packages/search-parser/src/errors.ts
+++ b/packages/search-parser/src/errors.ts
@@ -5,4 +5,5 @@ export const ERROR_CODES = {
   UNMATCHED_CLOSING_PARENTHESIS: 'unmatched-closing-parenthesis',
   UNCLOSED_QUOTED_STRING: 'unclosed-quoted-string',
   MISSING_OPERAND_FOR_NOT: 'missing-operand-for-not',
+  INVALID_OPERATOR: 'invalid-operator',
 };

--- a/packages/search-parser/src/index.ts
+++ b/packages/search-parser/src/index.ts
@@ -2,7 +2,11 @@ export { ERROR_CODES } from './errors';
 
 export { simplifyExpression } from './optimization';
 
+export { DEFAULT_OPERATOR, DEFAULT_OPERATORS } from './operators';
+
 export { parseSearchQuery } from './parser';
+
+export type { ParseSearchQueryOperatorOptions, ParseSearchQueryOptions } from './parser';
 
 export type {
   AndExpression,

--- a/packages/search-parser/src/operators.test.ts
+++ b/packages/search-parser/src/operators.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from 'vitest';
+import { ERROR_CODES } from './errors';
+import { createOperatorMatcher, DEFAULT_OPERATOR, DEFAULT_OPERATORS } from './operators';
+
+describe('operators', () => {
+  describe('createOperatorMatcher', () => {
+    describe('the longest operator always wins, so that an operator like >= is not shadowed by >, regardless of the order in which the operators are declared', () => {
+      test('matches the longest operator first', () => {
+        const { matcher } = createOperatorMatcher({
+          operators: ['=', '>', '>='],
+          defaultOperator: '=',
+        });
+
+        expect(matcher.matchAt('>=42', 0)).toEqual({ operator: '>=', length: 2 });
+      });
+
+      test('matches the longest custom operator first', () => {
+        const { matcher } = createOperatorMatcher({
+          operators: ['~', '~=', '='],
+          defaultOperator: '=',
+        });
+
+        expect(matcher.matchAt('~=42', 0)).toEqual({ operator: '~=', length: 2 });
+        expect(matcher.matchAt('~42', 0)).toEqual({ operator: '~', length: 1 });
+      });
+    });
+
+    test('matches operators at an arbitrary index', () => {
+      const { matcher } = createOperatorMatcher({
+        operators: DEFAULT_OPERATORS,
+        defaultOperator: DEFAULT_OPERATOR,
+      });
+
+      expect(matcher.matchAt('tag:>=42', 4)).toEqual({ operator: '>=', length: 2 });
+    });
+
+    test('returns undefined when no operator matches', () => {
+      const { matcher } = createOperatorMatcher({
+        operators: DEFAULT_OPERATORS,
+        defaultOperator: DEFAULT_OPERATOR,
+      });
+
+      expect(matcher.matchAt('invoice', 0)).toBe(undefined);
+    });
+
+    describe('as the parser is error resilient, invalid operators are discarded and reported as issues, instead of throwing', () => {
+      test('discards empty operators', () => {
+        const { matcher, issues } = createOperatorMatcher({
+          operators: ['=', ''],
+          defaultOperator: '=',
+        });
+
+        expect(matcher.matchAt('', 0)).toBe(undefined);
+        expect(issues).toEqual([
+          {
+            code: ERROR_CODES.INVALID_OPERATOR,
+            message: 'Operators cannot be empty, it has been ignored',
+          },
+        ]);
+      });
+
+      test('discards operators containing characters that delimit tokens', () => {
+        const { matcher, issues } = createOperatorMatcher({
+          operators: ['=', 'a b', '(', '"'],
+          defaultOperator: '=',
+        });
+
+        expect(matcher.matchAt('(', 0)).toBe(undefined);
+        expect(issues).toEqual([
+          {
+            code: ERROR_CODES.INVALID_OPERATOR,
+            message:
+              'Operator "a b" cannot contain whitespaces, parentheses or quotes, it has been ignored',
+          },
+          {
+            code: ERROR_CODES.INVALID_OPERATOR,
+            message:
+              'Operator "(" cannot contain whitespaces, parentheses or quotes, it has been ignored',
+          },
+          {
+            code: ERROR_CODES.INVALID_OPERATOR,
+            message:
+              'Operator """ cannot contain whitespaces, parentheses or quotes, it has been ignored',
+          },
+        ]);
+      });
+
+      test('silently ignores duplicated operators', () => {
+        const { matcher, issues } = createOperatorMatcher({
+          operators: ['=', '=', '~'],
+          defaultOperator: '=',
+        });
+
+        expect(matcher.matchAt('~foo', 0)).toEqual({ operator: '~', length: 1 });
+        expect(issues).toEqual([]);
+      });
+    });
+  });
+});

--- a/packages/search-parser/src/operators.test.ts
+++ b/packages/search-parser/src/operators.test.ts
@@ -85,6 +85,69 @@ describe('operators', () => {
         ]);
       });
 
+      test('discards a default operator that is not one of the declared operators, falling back to `=`', () => {
+        const { matcher, issues } = createOperatorMatcher({
+          operators: ['=', '~'],
+          defaultOperator: '>',
+        });
+
+        expect(matcher.defaultOperator).toBe('=');
+        expect(issues).toEqual([
+          {
+            code: ERROR_CODES.INVALID_OPERATOR,
+            message:
+              'Default operator ">" is not one of the declared operators, "=" has been used instead',
+          },
+        ]);
+      });
+
+      test('discards a default operator that has itself been rejected', () => {
+        const { matcher, issues } = createOperatorMatcher({
+          operators: ['=', 'a b'],
+          defaultOperator: 'a b',
+        });
+
+        expect(matcher.defaultOperator).toBe('=');
+        expect(issues).toEqual([
+          {
+            code: ERROR_CODES.INVALID_OPERATOR,
+            message:
+              'Operator "a b" cannot contain whitespaces, parentheses or quotes, it has been ignored',
+          },
+          {
+            code: ERROR_CODES.INVALID_OPERATOR,
+            message:
+              'Default operator "a b" is not one of the declared operators, "=" has been used instead',
+          },
+        ]);
+      });
+
+      test('falls back to the first declared operator when `=` is not declared', () => {
+        const { matcher, issues } = createOperatorMatcher({
+          operators: ['~', '^'],
+          defaultOperator: '>',
+        });
+
+        expect(matcher.defaultOperator).toBe('~');
+        expect(issues).toEqual([
+          {
+            code: ERROR_CODES.INVALID_OPERATOR,
+            message:
+              'Default operator ">" is not one of the declared operators, "~" has been used instead',
+          },
+        ]);
+      });
+
+      test('falls back to `=` when every declared operator has been rejected', () => {
+        const { matcher, issues } = createOperatorMatcher({
+          operators: ['a b'],
+          defaultOperator: 'a b',
+        });
+
+        expect(matcher.defaultOperator).toBe('=');
+        expect(issues).toHaveLength(2);
+      });
+
       test('silently ignores duplicated operators', () => {
         const { matcher, issues } = createOperatorMatcher({
           operators: ['=', '=', '~'],

--- a/packages/search-parser/src/operators.test.ts
+++ b/packages/search-parser/src/operators.test.ts
@@ -138,14 +138,25 @@ describe('operators', () => {
         ]);
       });
 
-      test('falls back to `=` when every declared operator has been rejected', () => {
+      test('falls back to the built-in `=` when every declared operator has been rejected, as no declared operator is left', () => {
         const { matcher, issues } = createOperatorMatcher({
           operators: ['a b'],
           defaultOperator: 'a b',
         });
 
         expect(matcher.defaultOperator).toBe('=');
-        expect(issues).toHaveLength(2);
+        expect(issues).toEqual([
+          {
+            code: ERROR_CODES.INVALID_OPERATOR,
+            message:
+              'Operator "a b" cannot contain whitespaces, parentheses or quotes, it has been ignored',
+          },
+          {
+            code: ERROR_CODES.INVALID_OPERATOR,
+            message:
+              'No operator has been declared, the built-in "=" has been used for filters without an explicit operator',
+          },
+        ]);
       });
 
       test('silently ignores duplicated operators', () => {

--- a/packages/search-parser/src/operators.ts
+++ b/packages/search-parser/src/operators.ts
@@ -1,0 +1,70 @@
+import type { Issue, Operator } from './parser.types';
+import { ERROR_CODES } from './errors';
+
+export const DEFAULT_OPERATORS: readonly Operator[] = ['>=', '<=', '>', '<', '='];
+export const DEFAULT_OPERATOR: Operator = '=';
+
+// Operators are matched against the raw query, so they cannot contain characters that
+// delimit tokens, otherwise they would never be matched in unquoted filters like `tag:>=1`.
+const FORBIDDEN_OPERATOR_CHARACTERS = /[\s()"]/;
+
+export type OperatorMatch<TOperator extends string> = {
+  operator: TOperator;
+  length: number;
+};
+
+export type OperatorMatcher<TOperator extends string> = {
+  defaultOperator: TOperator;
+  matchAt: (input: string, index: number) => OperatorMatch<TOperator> | undefined;
+};
+
+/**
+ * Builds the operator matcher used by the tokenizer to recognize filter operators.
+ * Invalid operators are discarded and reported as issues, keeping the parser error-resilient.
+ */
+export function createOperatorMatcher<TOperator extends string>({
+  operators,
+  defaultOperator,
+}: {
+  operators: readonly TOperator[];
+  defaultOperator: TOperator;
+}): { matcher: OperatorMatcher<TOperator>; issues: Issue[] } {
+  const issues: Issue[] = [];
+  const validOperators = new Set<TOperator>();
+
+  for (const operator of operators) {
+    if (operator.length === 0) {
+      issues.push({
+        code: ERROR_CODES.INVALID_OPERATOR,
+        message: 'Operators cannot be empty, it has been ignored',
+      });
+      continue;
+    }
+
+    if (FORBIDDEN_OPERATOR_CHARACTERS.test(operator)) {
+      issues.push({
+        code: ERROR_CODES.INVALID_OPERATOR,
+        message: `Operator "${operator}" cannot contain whitespaces, parentheses or quotes, it has been ignored`,
+      });
+      continue;
+    }
+
+    validOperators.add(operator);
+  }
+
+  // Longest operators are matched first, so that `>=` takes precedence over `>`,
+  // regardless of the order in which the operators are declared.
+  const sortedOperators = [...validOperators].sort((a, b) => b.length - a.length);
+
+  const matchAt = (input: string, index: number): OperatorMatch<TOperator> | undefined => {
+    for (const operator of sortedOperators) {
+      if (input.startsWith(operator, index)) {
+        return { operator, length: operator.length };
+      }
+    }
+
+    return undefined;
+  };
+
+  return { matcher: { defaultOperator, matchAt }, issues };
+}

--- a/packages/search-parser/src/operators.ts
+++ b/packages/search-parser/src/operators.ts
@@ -18,6 +18,53 @@ export type OperatorMatcher<TOperator extends string> = {
   matchAt: (input: string, index: number) => OperatorMatch<TOperator> | undefined;
 };
 
+function getOperatorRejectionReason({ operator }: { operator: string }): string | undefined {
+  if (operator.length === 0) {
+    return 'Operators cannot be empty';
+  }
+
+  if (FORBIDDEN_OPERATOR_CHARACTERS.test(operator)) {
+    return `Operator "${operator}" cannot contain whitespaces, parentheses or quotes`;
+  }
+
+  return undefined;
+}
+
+/**
+ * Only a declared operator can end up in the AST, so a default operator that has been
+ * rejected, or that was never declared, falls back to a declared one. Otherwise filters
+ * without an explicit operator, like `tag:invoice`, would be given an operator the consumer
+ * does not know about.
+ */
+function resolveDefaultOperator<TOperator extends string>({
+  defaultOperator,
+  validOperators,
+}: {
+  defaultOperator: TOperator;
+  validOperators: readonly TOperator[];
+}): { resolvedDefaultOperator: TOperator; issues: Issue[] } {
+  if (validOperators.includes(defaultOperator)) {
+    return { resolvedDefaultOperator: defaultOperator, issues: [] };
+  }
+
+  // `=` is the operator a filter without an explicit one means by default, prefer it when
+  // it has been declared, and fall back to the first declared operator otherwise.
+  const fallbackOperator =
+    validOperators.find((operator) => operator === (DEFAULT_OPERATOR as string)) ??
+    validOperators[0] ??
+    (DEFAULT_OPERATOR as TOperator);
+
+  return {
+    resolvedDefaultOperator: fallbackOperator,
+    issues: [
+      {
+        code: ERROR_CODES.INVALID_OPERATOR,
+        message: `Default operator "${defaultOperator}" is not one of the declared operators, "${fallbackOperator}" has been used instead`,
+      },
+    ],
+  };
+}
+
 /**
  * Builds the operator matcher used by the tokenizer to recognize filter operators.
  * Invalid operators are discarded and reported as issues, keeping the parser error-resilient.
@@ -30,27 +77,32 @@ export function createOperatorMatcher<TOperator extends string>({
   defaultOperator: TOperator;
 }): { matcher: OperatorMatcher<TOperator>; issues: Issue[] } {
   const issues: Issue[] = [];
-  const validOperators = new Set<TOperator>();
+  const validOperators: TOperator[] = [];
 
   for (const operator of operators) {
-    if (operator.length === 0) {
+    if (validOperators.includes(operator)) {
+      continue;
+    }
+
+    const rejectionReason = getOperatorRejectionReason({ operator });
+
+    if (rejectionReason !== undefined) {
       issues.push({
         code: ERROR_CODES.INVALID_OPERATOR,
-        message: 'Operators cannot be empty, it has been ignored',
+        message: `${rejectionReason}, it has been ignored`,
       });
       continue;
     }
 
-    if (FORBIDDEN_OPERATOR_CHARACTERS.test(operator)) {
-      issues.push({
-        code: ERROR_CODES.INVALID_OPERATOR,
-        message: `Operator "${operator}" cannot contain whitespaces, parentheses or quotes, it has been ignored`,
-      });
-      continue;
-    }
-
-    validOperators.add(operator);
+    validOperators.push(operator);
   }
+
+  const { resolvedDefaultOperator, issues: defaultOperatorIssues } = resolveDefaultOperator({
+    defaultOperator,
+    validOperators,
+  });
+
+  issues.push(...defaultOperatorIssues);
 
   // Longest operators are matched first, so that `>=` takes precedence over `>`,
   // regardless of the order in which the operators are declared.
@@ -66,5 +118,5 @@ export function createOperatorMatcher<TOperator extends string>({
     return undefined;
   };
 
-  return { matcher: { defaultOperator, matchAt }, issues };
+  return { matcher: { defaultOperator: resolvedDefaultOperator, matchAt }, issues };
 }

--- a/packages/search-parser/src/operators.ts
+++ b/packages/search-parser/src/operators.ts
@@ -47,6 +47,21 @@ function resolveDefaultOperator<TOperator extends string>({
     return { resolvedDefaultOperator: defaultOperator, issues: [] };
   }
 
+  // Every declared operator has been rejected, so no declared operator is left to fall back
+  // to. Filters still need one, so the built-in `=` is used as a last resort, and the issue
+  // says so rather than claiming a declared operator was picked.
+  if (validOperators.length === 0) {
+    return {
+      resolvedDefaultOperator: DEFAULT_OPERATOR as TOperator,
+      issues: [
+        {
+          code: ERROR_CODES.INVALID_OPERATOR,
+          message: `No operator has been declared, the built-in "${DEFAULT_OPERATOR}" has been used for filters without an explicit operator`,
+        },
+      ],
+    };
+  }
+
   // `=` is the operator a filter without an explicit one means by default, prefer it when
   // it has been declared, and fall back to the first declared operator otherwise.
   const fallbackOperator =

--- a/packages/search-parser/src/optimization.ts
+++ b/packages/search-parser/src/optimization.ts
@@ -8,8 +8,12 @@ import type { AndExpression, Expression, NotExpression, OrExpression } from './p
  * - Redundant expressions are removed (duplicates, empty expressions).
  * - Empty AND/OR expressions are converted to 'empty'.
  */
-export function simplifyExpression({ expression }: { expression: Expression }): {
-  expression: Expression;
+export function simplifyExpression<TOperator extends string>({
+  expression,
+}: {
+  expression: Expression<TOperator>;
+}): {
+  expression: Expression<TOperator>;
 } {
   if (expression.type === 'empty' || expression.type === 'text' || expression.type === 'filter') {
     return { expression };
@@ -27,8 +31,12 @@ export function simplifyExpression({ expression }: { expression: Expression }): 
   return { expression };
 }
 
-export function simplifyOperands({ operands }: { operands: Expression[] }): {
-  simplifiedOperands: Expression[];
+export function simplifyOperands<TOperator extends string>({
+  operands,
+}: {
+  operands: Expression<TOperator>[];
+}): {
+  simplifiedOperands: Expression<TOperator>[];
 } {
   const simplifiedOperands = operands.map(
     (expression) => simplifyExpression({ expression }).expression,
@@ -37,8 +45,12 @@ export function simplifyOperands({ operands }: { operands: Expression[] }): {
   return { simplifiedOperands };
 }
 
-function simplifyNotExpression({ expression }: { expression: NotExpression }): {
-  expression: Expression;
+function simplifyNotExpression<TOperator extends string>({
+  expression,
+}: {
+  expression: NotExpression<TOperator>;
+}): {
+  expression: Expression<TOperator>;
 } {
   const { expression: simplifiedOperandExpression } = simplifyExpression({
     expression: expression.operand,
@@ -57,8 +69,12 @@ function simplifyNotExpression({ expression }: { expression: NotExpression }): {
   return { expression: { type: 'not', operand: simplifiedOperandExpression } };
 }
 
-function simplifyAndOrExpression({ expression }: { expression: AndExpression | OrExpression }): {
-  expression: Expression;
+function simplifyAndOrExpression<TOperator extends string>({
+  expression,
+}: {
+  expression: AndExpression<TOperator> | OrExpression<TOperator>;
+}): {
+  expression: Expression<TOperator>;
 } {
   const { simplifiedOperands } = simplifyOperands({ operands: expression.operands });
   const filteredOperands = simplifiedOperands.filter((op) => op.type !== 'empty');
@@ -85,10 +101,16 @@ function simplifyAndOrExpression({ expression }: { expression: AndExpression | O
   };
 }
 
-function flattenOperands({ type, operands }: { type: 'and' | 'or'; operands: Expression[] }): {
-  flattenedOperands: Expression[];
+function flattenOperands<TOperator extends string>({
+  type,
+  operands,
+}: {
+  type: 'and' | 'or';
+  operands: Expression<TOperator>[];
+}): {
+  flattenedOperands: Expression<TOperator>[];
 } {
-  const flattenedOperands: Expression[] = [];
+  const flattenedOperands: Expression<TOperator>[] = [];
 
   for (const operand of operands) {
     // When the operand is of the same type, inline its operands
@@ -103,10 +125,14 @@ function flattenOperands({ type, operands }: { type: 'and' | 'or'; operands: Exp
   return { flattenedOperands };
 }
 
-function deduplicateOperands({ operands }: { operands: Expression[] }): {
-  deduplicatedOperands: Expression[];
+function deduplicateOperands<TOperator extends string>({
+  operands,
+}: {
+  operands: Expression<TOperator>[];
+}): {
+  deduplicatedOperands: Expression<TOperator>[];
 } {
-  const deduplicatedOperands: Expression[] = [];
+  const deduplicatedOperands: Expression<TOperator>[] = [];
 
   for (const operand of operands) {
     const isDuplicate = deduplicatedOperands.some((existing) =>
@@ -120,7 +146,10 @@ function deduplicateOperands({ operands }: { operands: Expression[] }): {
   return { deduplicatedOperands };
 }
 
-export function areExpressionsIdentical(a: Expression, b: Expression): boolean {
+export function areExpressionsIdentical<TOperator extends string>(
+  a: Expression<TOperator>,
+  b: Expression<TOperator>,
+): boolean {
   if (a.type !== b.type) {
     return false;
   }

--- a/packages/search-parser/src/parser.test.ts
+++ b/packages/search-parser/src/parser.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'vitest';
+import { ERROR_CODES } from './errors';
 import { parseSearchQuery } from './parser';
 
 describe('parseSearchQuery', () => {
@@ -885,6 +886,108 @@ describe('parseSearchQuery', () => {
         ],
       });
       expect(result.issues).toEqual([]);
+    });
+  });
+  describe('when parsing queries with custom operators', () => {
+    const operators = ['>=', '<=', '>', '<', '=', '~'] as const;
+
+    test('parses a custom operator in an unquoted filter', () => {
+      expect(parseSearchQuery({ query: 'tag:~invoice', operators })).toEqual({
+        expression: { type: 'filter', field: 'tag', operator: '~', value: 'invoice' },
+        issues: [],
+      });
+    });
+
+    test('parses a custom operator with a quoted value', () => {
+      expect(parseSearchQuery({ query: 'name:~"my invoice"', operators })).toEqual({
+        expression: { type: 'filter', field: 'name', operator: '~', value: 'my invoice' },
+        issues: [],
+      });
+    });
+
+    test('parses a custom operator with a quoted field', () => {
+      expect(parseSearchQuery({ query: '"my field":~42', operators })).toEqual({
+        expression: { type: 'filter', field: 'my field', operator: '~', value: '42' },
+        issues: [],
+      });
+    });
+
+    test('parses a custom operator behind a negation', () => {
+      expect(parseSearchQuery({ query: '-tag:~invoice', operators })).toEqual({
+        expression: {
+          type: 'not',
+          operand: { type: 'filter', field: 'tag', operator: '~', value: 'invoice' },
+        },
+        issues: [],
+      });
+    });
+
+    test('parses custom operators alongside built-in ones', () => {
+      expect(
+        parseSearchQuery({ query: 'name:~invoice AND createdAt:>=2024-01-01', operators }),
+      ).toEqual({
+        expression: {
+          type: 'and',
+          operands: [
+            { type: 'filter', field: 'name', operator: '~', value: 'invoice' },
+            { type: 'filter', field: 'createdAt', operator: '>=', value: '2024-01-01' },
+          ],
+        },
+        issues: [],
+      });
+    });
+
+    test('matches the longest operator, regardless of the order in which they are declared', () => {
+      expect(parseSearchQuery({ query: 'tag:~=invoice', operators: ['~', '~=', '='] })).toEqual({
+        expression: { type: 'filter', field: 'tag', operator: '~=', value: 'invoice' },
+        issues: [],
+      });
+    });
+
+    test('an operator that is not declared is part of the value', () => {
+      expect(parseSearchQuery({ query: 'tag:~invoice', operators: ['='] })).toEqual({
+        expression: { type: 'filter', field: 'tag', operator: '=', value: '~invoice' },
+        issues: [],
+      });
+    });
+
+    test('falls back to the default operator when no operator is present', () => {
+      expect(parseSearchQuery({ query: 'tag:invoice', operators })).toEqual({
+        expression: { type: 'filter', field: 'tag', operator: '=', value: 'invoice' },
+        issues: [],
+      });
+    });
+
+    test('uses the provided default operator when no operator is present', () => {
+      expect(parseSearchQuery({ query: 'tag:invoice', operators, defaultOperator: '~' })).toEqual({
+        expression: { type: 'filter', field: 'tag', operator: '~', value: 'invoice' },
+        issues: [],
+      });
+    });
+
+    test('reports invalid operators as issues while still parsing the query', () => {
+      expect(parseSearchQuery({ query: 'tag:invoice', operators: ['=', 'a b'] })).toEqual({
+        expression: { type: 'filter', field: 'tag', operator: '=', value: 'invoice' },
+        issues: [
+          {
+            code: ERROR_CODES.INVALID_OPERATOR,
+            message:
+              'Operator "a b" cannot contain whitespaces, parentheses or quotes, it has been ignored',
+          },
+        ],
+      });
+    });
+
+    test('keeps the built-in operators when the operators option is omitted', () => {
+      expect(parseSearchQuery({ query: 'createdAt:>=2024-01-01' })).toEqual({
+        expression: { type: 'filter', field: 'createdAt', operator: '>=', value: '2024-01-01' },
+        issues: [],
+      });
+
+      expect(parseSearchQuery({ query: 'tag:~invoice' })).toEqual({
+        expression: { type: 'filter', field: 'tag', operator: '=', value: '~invoice' },
+        issues: [],
+      });
     });
   });
 });

--- a/packages/search-parser/src/parser.ts
+++ b/packages/search-parser/src/parser.ts
@@ -1,25 +1,57 @@
-import type { Expression, Issue, ParsedQuery } from './parser.types';
+import type { Expression, Issue, Operator, ParsedQuery } from './parser.types';
 import type { Token } from './tokenizer';
 import { ERROR_CODES } from './errors';
 import { simplifyExpression } from './optimization';
+import { createOperatorMatcher, DEFAULT_OPERATOR, DEFAULT_OPERATORS } from './operators';
 import { tokenize } from './tokenizer';
 
-export function parseSearchQuery({
-  query,
-  maxDepth = 10,
-  maxTokens = 200,
-  optimize = true,
-}: {
+export type ParseSearchQueryOptions = {
   query: string;
   maxDepth?: number;
   maxTokens?: number;
   optimize?: boolean;
-}): ParsedQuery {
-  const { tokens, issues: tokenizerIssues } = tokenize({ query, maxTokens });
+};
+
+/**
+ * `defaultOperator` is what a filter without an explicit operator, like `tag:invoice`, means.
+ * It defaults to `=`, so it only becomes required when `=` is dropped from the operator set,
+ * as there would otherwise be no sound value to fall back to.
+ */
+export type ParseSearchQueryOperatorOptions<TOperator extends string> = '=' extends TOperator
+  ? { operators?: readonly TOperator[]; defaultOperator?: NoInfer<TOperator> }
+  : { operators: readonly TOperator[]; defaultOperator: NoInfer<TOperator> };
+
+export function parseSearchQuery<const TOperator extends string = Operator>(
+  options: ParseSearchQueryOptions & ParseSearchQueryOperatorOptions<TOperator>,
+): ParsedQuery<TOperator> {
+  // The conditional operator options are deferred while TOperator is unresolved, so they are
+  // read through the shape both of its branches share.
+  const {
+    query,
+    maxDepth = 10,
+    maxTokens = 200,
+    optimize = true,
+    operators = DEFAULT_OPERATORS as readonly TOperator[],
+    defaultOperator = DEFAULT_OPERATOR as TOperator,
+  } = options as ParseSearchQueryOptions & {
+    operators?: readonly TOperator[];
+    defaultOperator?: TOperator;
+  };
+
+  const { matcher, issues: operatorIssues } = createOperatorMatcher({
+    operators,
+    defaultOperator,
+  });
+
+  const { tokens, issues: tokenizerIssues } = tokenize({
+    query,
+    maxTokens,
+    operatorMatcher: matcher,
+  });
 
   const { expression, issues: parserIssues } = parseExpression({ tokens, maxDepth });
 
-  const issues = [...tokenizerIssues, ...parserIssues];
+  const issues = [...operatorIssues, ...tokenizerIssues, ...parserIssues];
 
   if (!optimize) {
     return {
@@ -36,14 +68,20 @@ export function parseSearchQuery({
   };
 }
 
-function parseExpression({ tokens, maxDepth }: { tokens: Token[]; maxDepth: number }): ParsedQuery {
+function parseExpression<TOperator extends string>({
+  tokens,
+  maxDepth,
+}: {
+  tokens: Token<TOperator>[];
+  maxDepth: number;
+}): ParsedQuery<TOperator> {
   const parserIssues: Issue[] = [];
 
   let currentTokenIndex = 0;
   let currentDepth = 0;
 
-  const peek = (): Token => tokens[currentTokenIndex] ?? { type: 'EOF' };
-  const advance = (): Token => tokens[currentTokenIndex++] ?? { type: 'EOF' };
+  const peek = (): Token<TOperator> => tokens[currentTokenIndex] ?? { type: 'EOF' };
+  const advance = (): Token<TOperator> => tokens[currentTokenIndex++] ?? { type: 'EOF' };
 
   const checkDepth = (): boolean => {
     if (currentDepth >= maxDepth) {
@@ -57,7 +95,7 @@ function parseExpression({ tokens, maxDepth }: { tokens: Token[]; maxDepth: numb
   };
 
   // Parse primary expression (filter, parentheses, text)
-  function parsePrimaryExpression(): Expression | undefined {
+  function parsePrimaryExpression(): Expression<TOperator> | undefined {
     const token = peek();
 
     if (token.type === 'LPAREN') {
@@ -104,7 +142,7 @@ function parseExpression({ tokens, maxDepth }: { tokens: Token[]; maxDepth: numb
     return undefined;
   }
 
-  function parseUnaryExpression(): Expression | undefined {
+  function parseUnaryExpression(): Expression<TOperator> | undefined {
     if (peek().type === 'NOT') {
       advance(); // Consume NOT
 
@@ -130,8 +168,8 @@ function parseExpression({ tokens, maxDepth }: { tokens: Token[]; maxDepth: numb
     return parsePrimaryExpression();
   }
 
-  function parseAndExpression(): Expression | undefined {
-    const operands: Expression[] = [];
+  function parseAndExpression(): Expression<TOperator> | undefined {
+    const operands: Expression<TOperator>[] = [];
 
     while (true) {
       const next = peek();
@@ -164,13 +202,13 @@ function parseExpression({ tokens, maxDepth }: { tokens: Token[]; maxDepth: numb
     return { type: 'and', operands };
   }
 
-  function parseOrExpression(): Expression | undefined {
+  function parseOrExpression(): Expression<TOperator> | undefined {
     const left = parseAndExpression();
     if (!left) {
       return undefined;
     }
 
-    const operands: Expression[] = [left];
+    const operands: Expression<TOperator>[] = [left];
 
     while (peek().type === 'OR') {
       advance(); // Consume OR

--- a/packages/search-parser/src/parser.types.test.ts
+++ b/packages/search-parser/src/parser.types.test.ts
@@ -1,5 +1,6 @@
 import type { FilterExpression, Operator } from './parser.types';
 import { describe, expect, test } from 'vitest';
+import { ERROR_CODES } from './errors';
 import { DEFAULT_OPERATORS } from './operators';
 import { parseSearchQuery } from './parser';
 
@@ -26,15 +27,23 @@ describe('parser types', () => {
     }
   });
 
-  test('the default operator has to be one of the declared operators', () => {
-    const { expression } = parseSearchQuery({
+  test('the default operator has to be one of the declared operators, and is discarded at runtime otherwise', () => {
+    const { expression, issues } = parseSearchQuery({
       query: 'tag:invoice',
       operators: ['=', '~'],
       // @ts-expect-error `>` is not part of the declared operators
       defaultOperator: '>',
     });
 
-    expect(expression).toEqual({ type: 'filter', field: 'tag', operator: '>', value: 'invoice' });
+    // Untyped consumers can still reach this, so the undeclared default is discarded
+    expect(expression).toEqual({ type: 'filter', field: 'tag', operator: '=', value: 'invoice' });
+    expect(issues).toEqual([
+      {
+        code: ERROR_CODES.INVALID_OPERATOR,
+        message:
+          'Default operator ">" is not one of the declared operators, "=" has been used instead',
+      },
+    ]);
   });
 
   test('the built-in operators can be spread to extend them, rather than restated', () => {

--- a/packages/search-parser/src/parser.types.test.ts
+++ b/packages/search-parser/src/parser.types.test.ts
@@ -1,0 +1,78 @@
+import type { FilterExpression, Operator } from './parser.types';
+import { describe, expect, test } from 'vitest';
+import { DEFAULT_OPERATORS } from './operators';
+import { parseSearchQuery } from './parser';
+
+// These assertions are enforced by `tsc --noEmit`, the runtime expectations only
+// ensure the file is also covered by the test suite.
+describe('parser types', () => {
+  test('the built-in operator union is preserved when no custom operators are provided', () => {
+    const { expression } = parseSearchQuery({ query: 'tag:invoice' });
+
+    if (expression.type === 'filter') {
+      const operator: Operator = expression.operator;
+
+      expect(operator).toBe('=');
+    }
+  });
+
+  test('custom operators are inferred as a literal union, without requiring `as const`', () => {
+    const { expression } = parseSearchQuery({ query: 'tag:~invoice', operators: ['=', '~'] });
+
+    if (expression.type === 'filter') {
+      const operator: '=' | '~' = expression.operator;
+
+      expect(operator).toBe('~');
+    }
+  });
+
+  test('the default operator has to be one of the declared operators', () => {
+    const { expression } = parseSearchQuery({
+      query: 'tag:invoice',
+      operators: ['=', '~'],
+      // @ts-expect-error `>` is not part of the declared operators
+      defaultOperator: '>',
+    });
+
+    expect(expression).toEqual({ type: 'filter', field: 'tag', operator: '>', value: 'invoice' });
+  });
+
+  test('the built-in operators can be spread to extend them, rather than restated', () => {
+    const { expression } = parseSearchQuery({
+      query: 'name:~invoice',
+      operators: [...DEFAULT_OPERATORS, '~'],
+    });
+
+    if (expression.type === 'filter') {
+      const operator: Operator | '~' = expression.operator;
+
+      expect(operator).toBe('~');
+    }
+  });
+
+  test('the default operator is required when `=` is dropped from the operator set', () => {
+    const { expression } = parseSearchQuery({
+      query: 'tag:invoice',
+      operators: ['~'],
+      defaultOperator: '~',
+    });
+
+    // @ts-expect-error `defaultOperator` is required, as `=` is not a declared operator
+    parseSearchQuery({ query: 'tag:invoice', operators: ['~'] });
+
+    expect(expression).toEqual({ type: 'filter', field: 'tag', operator: '~', value: 'invoice' });
+  });
+
+  test('the expression types stay usable without a type argument, for consumers of the built-in operators', () => {
+    const filter: FilterExpression = { type: 'filter', field: 'tag', operator: '>=', value: '42' };
+    const operatorsMap: Record<Operator, string> = {
+      '=': 'eq',
+      '<': 'lt',
+      '<=': 'lte',
+      '>': 'gt',
+      '>=': 'gte',
+    };
+
+    expect(operatorsMap[filter.operator]).toBe('gte');
+  });
+});

--- a/packages/search-parser/src/parser.types.ts
+++ b/packages/search-parser/src/parser.types.ts
@@ -3,16 +3,16 @@ export type Issue = {
   code: string;
 };
 
-export type ParsedQuery = {
-  expression: Expression;
+export type ParsedQuery<TOperator extends string = Operator> = {
+  expression: Expression<TOperator>;
   issues: Issue[];
 };
 
-export type Expression =
-  | AndExpression
-  | OrExpression
-  | NotExpression
-  | FilterExpression
+export type Expression<TOperator extends string = Operator> =
+  | AndExpression<TOperator>
+  | OrExpression<TOperator>
+  | NotExpression<TOperator>
+  | FilterExpression<TOperator>
   | TextExpression
   | EmptyExpression;
 
@@ -20,27 +20,27 @@ export type EmptyExpression = {
   type: 'empty';
 };
 
-export type AndExpression = {
+export type AndExpression<TOperator extends string = Operator> = {
   type: 'and';
-  operands: Expression[];
+  operands: Expression<TOperator>[];
 };
 
-export type OrExpression = {
+export type OrExpression<TOperator extends string = Operator> = {
   type: 'or';
-  operands: Expression[];
+  operands: Expression<TOperator>[];
 };
 
-export type NotExpression = {
+export type NotExpression<TOperator extends string = Operator> = {
   type: 'not';
-  operand: Expression;
+  operand: Expression<TOperator>;
 };
 
 export type Operator = '>' | '<' | '>=' | '<=' | '=';
 
-export type FilterExpression = {
+export type FilterExpression<TOperator extends string = Operator> = {
   type: 'filter';
   field: string;
-  operator: Operator;
+  operator: TOperator;
   value: string;
 };
 

--- a/packages/search-parser/src/tokenizer.test.ts
+++ b/packages/search-parser/src/tokenizer.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from 'vitest';
+import { createOperatorMatcher, DEFAULT_OPERATOR, DEFAULT_OPERATORS } from './operators';
 import { tokenize } from './tokenizer';
+
+const { matcher: operatorMatcher } = createOperatorMatcher({
+  operators: DEFAULT_OPERATORS,
+  defaultOperator: DEFAULT_OPERATOR,
+});
 
 describe('tokenizer', () => {
   describe('tokenize', () => {
@@ -129,7 +135,7 @@ describe('tokenizer', () => {
 
       for (const { query, expectedTokens, maxTokens = 100 } of queries) {
         test(`tokenizes "${query}"`, () => {
-          const result = tokenize({ query, maxTokens });
+          const result = tokenize({ query, maxTokens, operatorMatcher });
           expect(result.tokens).to.eql(expectedTokens);
         });
       }

--- a/packages/search-parser/src/tokenizer.ts
+++ b/packages/search-parser/src/tokenizer.ts
@@ -1,19 +1,20 @@
-import type { Issue, Operator } from './parser.types';
+import type { OperatorMatcher } from './operators';
+import type { Issue } from './parser.types';
 import { ERROR_CODES } from './errors';
 import { isWhitespace } from './string';
 
-export type Token =
+export type Token<TOperator extends string> =
   | { type: 'LPAREN' }
   | { type: 'RPAREN' }
   | { type: 'AND' }
   | { type: 'OR' }
   | { type: 'NOT' }
-  | { type: 'FILTER'; field: string; operator: Operator; value: string }
+  | { type: 'FILTER'; field: string; operator: TOperator; value: string }
   | { type: 'TEXT'; value: string }
   | { type: 'EOF' };
 
-export type TokenizeResult = {
-  tokens: Token[];
+export type TokenizeResult<TOperator extends string> = {
+  tokens: Token<TOperator>[];
   issues: Issue[];
 };
 
@@ -27,14 +28,16 @@ function isWhitespaceOrParen(char: string): boolean {
   return isWhitespace(char) || char === '(' || char === ')';
 }
 
-export function tokenize({
+export function tokenize<TOperator extends string>({
   query,
   maxTokens,
+  operatorMatcher,
 }: {
   query: string;
   maxTokens: number;
-}): TokenizeResult {
-  const tokens: Token[] = [];
+  operatorMatcher: OperatorMatcher<TOperator>;
+}): TokenizeResult<TOperator> {
+  const tokens: Token<TOperator>[] = [];
   const issues: Issue[] = [];
   let pos = 0;
 
@@ -153,25 +156,10 @@ export function tokenize({
     return unescapeColons(value);
   };
 
-  const readFilterOperatorAndValue = (): { operator: Operator; value: string } => {
-    let operator: Operator = '=';
-
-    if (query.startsWith('>=', pos)) {
-      operator = '>=';
-      pos += 2;
-    } else if (query.startsWith('<=', pos)) {
-      operator = '<=';
-      pos += 2;
-    } else if (peek() === '>') {
-      operator = '>';
-      pos++;
-    } else if (peek() === '<') {
-      operator = '<';
-      pos++;
-    } else if (peek() === '=') {
-      operator = '=';
-      pos++;
-    }
+  const readFilterOperatorAndValue = (): { operator: TOperator; value: string } => {
+    const match = operatorMatcher.matchAt(query, pos);
+    const operator = match?.operator ?? operatorMatcher.defaultOperator;
+    pos += match?.length ?? 0;
 
     const value = readFilterValue();
 
@@ -187,7 +175,7 @@ export function tokenize({
     return false;
   };
 
-  const parseFilter = (token: string): Token | undefined => {
+  const parseFilter = (token: string): Token<TOperator> | undefined => {
     // Check for unescaped colons
     if (!hasUnescapedColon(token)) {
       return undefined;
@@ -210,25 +198,9 @@ export function tokenize({
     const afterColon = token.slice(firstColonIndex + 1);
 
     // Check for operator at the start
-    let operator: Operator = '=';
-    let operatorLength = 0;
-
-    if (afterColon.startsWith('>=')) {
-      operator = '>=';
-      operatorLength = 2;
-    } else if (afterColon.startsWith('<=')) {
-      operator = '<=';
-      operatorLength = 2;
-    } else if (afterColon.startsWith('>')) {
-      operator = '>';
-      operatorLength = 1;
-    } else if (afterColon.startsWith('<')) {
-      operator = '<';
-      operatorLength = 1;
-    } else if (afterColon.startsWith('=')) {
-      operator = '=';
-      operatorLength = 1;
-    }
+    const match = operatorMatcher.matchAt(afterColon, 0);
+    const operator = match?.operator ?? operatorMatcher.defaultOperator;
+    const operatorLength = match?.length ?? 0;
 
     // If there's nothing after the operator in the token, read the value from input
     let value = unescapeColons(afterColon.slice(operatorLength));


### PR DESCRIPTION
Closes #1440

Adds an `operators` option to `parseSearchQuery`, so the built-in `>`, `<`, `>=`, `<=` and `=` set can be replaced with a custom one. This covers the `~` "contains" operator asked for in the issue, without hardcoding it:

```ts
import { DEFAULT_OPERATORS, parseSearchQuery } from '@papra/search-parser';

parseSearchQuery({ query: 'name:~invoice', operators: [...DEFAULT_OPERATORS, '~'] });
// { expression: { type: 'filter', field: 'name', operator: '~', value: 'invoice' }, issues: [] }
```

It works everywhere a built-in operator does: quoted values (`name:~"hello world"`), quoted fields (`"my field":~42`), negation (`-name:~foo`), and mixed with the built-ins (`name:~a AND createdAt:>=2024-01-01`).

## Implementation notes

- **One matcher instead of two ladders.** The operator matching was duplicated in the tokenizer, once in `readFilterOperatorAndValue` for quoted fields and once in `parseFilter` for unquoted ones. Both now go through a single matcher in the new `operators.ts`.
- **Longest match wins.** The matcher sorts operators by length, so `>=` is never shadowed by `>`, and a custom `~=` is never shadowed by `~`, whatever order they are declared in.
- **Invalid operators are reported, not silently dropped.** Operators containing whitespaces, parentheses or quotes can never be matched in unquoted filters, since those characters delimit tokens. They are discarded and reported as `invalid-operator` issues, which keeps the parser's error-resilient contract instead of throwing or failing quietly.
- **`defaultOperator`** is what a filter without an explicit operator (`tag:invoice`) means. It defaults to `=`, and is required when `=` is not one of the declared operators — otherwise the inferred operator type would claim an operator the parser can't actually return.

## Types

The AST types now take an operator type argument that defaults to the built-in `Operator` union, so existing usage is unchanged:

```ts
const filter: FilterExpression = { type: 'filter', field: 'tag', operator: '>=', value: '42' };
const map: Record<Operator, BinaryOperator> = { /* ... */ };
```

Custom operators are inferred as a literal union without needing `as const`, so `expression.operator` stays narrowed rather than widening to `string`. The inference contract and both compile-time guards are locked in by `@ts-expect-error` assertions in `parser.types.test.ts`, which fail the type check if they ever regress.

## Scope

Operators only apply right after the colon (`name:~invoice`, not `name~invoice`). Supporting the colon-less form would mean scanning every unquoted token for operator substrings, which would reclassify plain text like `foo-bar` or `a=b` as filters. The existing `field:<op>value` grammar already covers the use case in the issue.

## Checks

- `@papra/search-parser`: 137 tests pass (113 pre-existing ones unmodified, plus 24 new), type check, build, lint and format all clean.
- Behaviour is unchanged when `operators` is omitted: `name:~invoice` still parses to `{ operator: '=', value: '~invoice' }`.
- `@papra/app-server` and `@papra/app-client` type check clean against the change, and the 158 `document-search` tests in `@papra/app-server` pass.
