### PR TITLE
fix(papra-client): include tag name in delete confirmation

### DIFF
--- a/.changeset/friendly-tags-delete.md
+++ b/.changeset/friendly-tags-delete.md
@@ -1,0 +1,5 @@
+---
+'@papra/app': patch
+---
+
+Include the tag name in the tag deletion confirmation message.

--- a/apps/papra-client/src/locales/ca.dictionary.ts
+++ b/apps/papra-client/src/locales/ca.dictionary.ts
@@ -778,7 +778,7 @@ export const translations = {
   'tags.delete': "Suprimeix l'etiqueta",
   'tags.delete.confirm.title': "Suprimeix l'etiqueta",
   'tags.delete.confirm.message':
-    "Estàs segur que vols suprimir aquesta etiqueta? Suprimir-la l'eliminarà de tots els documents.",
+    'Estàs segur que vols suprimir l\'etiqueta "{{ name }}"? Suprimir-la l\'eliminarà de tots els documents.',
   'tags.delete.confirm.confirm-button': 'Suprimeix',
   'tags.delete.confirm.cancel-button': 'Cancel·la',
   'tags.delete.success': 'Etiqueta suprimida correctament',

--- a/apps/papra-client/src/locales/de.dictionary.ts
+++ b/apps/papra-client/src/locales/de.dictionary.ts
@@ -758,7 +758,7 @@ export const translations: Partial<TranslationsDictionary> = {
   'tags.delete': 'Tag löschen',
   'tags.delete.confirm.title': 'Tag löschen',
   'tags.delete.confirm.message':
-    'Sind Sie sicher, dass Sie diesen Tag löschen möchten? Das Löschen eines Tags entfernt ihn von allen Dokumenten.',
+    'Sind Sie sicher, dass Sie den Tag "{{ name }}" löschen möchten? Das Löschen eines Tags entfernt ihn von allen Dokumenten.',
   'tags.delete.confirm.confirm-button': 'Löschen',
   'tags.delete.confirm.cancel-button': 'Abbrechen',
   'tags.delete.success': 'Tag erfolgreich gelöscht',

--- a/apps/papra-client/src/locales/el.dictionary.ts
+++ b/apps/papra-client/src/locales/el.dictionary.ts
@@ -746,7 +746,7 @@ export const translations: Partial<TranslationsDictionary> = {
   'tags.delete': 'Διαγραφή ετικέτας',
   'tags.delete.confirm.title': 'Διαγραφή ετικέτας',
   'tags.delete.confirm.message':
-    'Είστε βέβαιοι ότι θέλετε να διαγράψετε αυτή την ετικέτα; Θα αφαιρεθεί από όλα τα έγγραφα.',
+    'Είστε βέβαιοι ότι θέλετε να διαγράψετε την ετικέτα "{{ name }}"; Θα αφαιρεθεί από όλα τα έγγραφα.',
   'tags.delete.confirm.confirm-button': 'Διαγραφή',
   'tags.delete.confirm.cancel-button': 'Ακύρωση',
   'tags.delete.success': 'Η ετικέτα διαγράφηκε',

--- a/apps/papra-client/src/locales/en.dictionary.ts
+++ b/apps/papra-client/src/locales/en.dictionary.ts
@@ -748,7 +748,7 @@ export const translations = {
   'tags.delete': 'Delete tag',
   'tags.delete.confirm.title': 'Delete tag',
   'tags.delete.confirm.message':
-    'Are you sure you want to delete this tag? Deleting a tag will remove it from all documents.',
+    'Are you sure you want to delete the tag "{{ name }}"? Deleting a tag will remove it from all documents.',
   'tags.delete.confirm.confirm-button': 'Delete',
   'tags.delete.confirm.cancel-button': 'Cancel',
   'tags.delete.success': 'Tag deleted successfully',

--- a/apps/papra-client/src/locales/es.dictionary.ts
+++ b/apps/papra-client/src/locales/es.dictionary.ts
@@ -749,7 +749,7 @@ export const translations: Partial<TranslationsDictionary> = {
   'tags.delete': 'Eliminar etiqueta',
   'tags.delete.confirm.title': 'Eliminar etiqueta',
   'tags.delete.confirm.message':
-    '¿Estás seguro de que deseas eliminar esta etiqueta? Eliminar una etiqueta la quitará de todos los documentos.',
+    '¿Estás seguro de que deseas eliminar la etiqueta "{{ name }}"? Eliminar una etiqueta la quitará de todos los documentos.',
   'tags.delete.confirm.confirm-button': 'Eliminar',
   'tags.delete.confirm.cancel-button': 'Cancelar',
   'tags.delete.success': 'Etiqueta eliminada exitosamente',

--- a/apps/papra-client/src/locales/fr.dictionary.ts
+++ b/apps/papra-client/src/locales/fr.dictionary.ts
@@ -747,7 +747,7 @@ export const translations: Partial<TranslationsDictionary> = {
   'tags.delete': 'Supprimer un tag',
   'tags.delete.confirm.title': 'Supprimer un tag',
   'tags.delete.confirm.message':
-    "Êtes-vous sûr de vouloir supprimer ce tag ? Supprimer un tag supprimera toutes les règles de catégorisation qui l'utilisent.",
+    'Êtes-vous sûr de vouloir supprimer le tag "{{ name }}" ? Supprimer un tag supprimera toutes les règles de catégorisation qui l\'utilisent.',
   'tags.delete.confirm.confirm-button': 'Supprimer',
   'tags.delete.confirm.cancel-button': 'Annuler',
   'tags.delete.success': 'Tag supprimé avec succès',

--- a/apps/papra-client/src/locales/it.dictionary.ts
+++ b/apps/papra-client/src/locales/it.dictionary.ts
@@ -747,7 +747,7 @@ export const translations: Partial<TranslationsDictionary> = {
   'tags.delete': 'Elimina tag',
   'tags.delete.confirm.title': 'Elimina tag',
   'tags.delete.confirm.message':
-    'Sei sicuro di voler eliminare questo tag? Il tag verrà rimosso da tutti i documenti.',
+    'Sei sicuro di voler eliminare il tag "{{ name }}"? Il tag verrà rimosso da tutti i documenti.',
   'tags.delete.confirm.confirm-button': 'Elimina',
   'tags.delete.confirm.cancel-button': 'Annulla',
   'tags.delete.success': 'Tag eliminato con successo',

--- a/apps/papra-client/src/locales/nl.dictionary.ts
+++ b/apps/papra-client/src/locales/nl.dictionary.ts
@@ -744,7 +744,7 @@ export const translations: Partial<TranslationsDictionary> = {
   'tags.delete': 'Label verwijderen',
   'tags.delete.confirm.title': 'Label verwijderen',
   'tags.delete.confirm.message':
-    'Weet u zeker dat u dit label wilt verwijderen? Het verwijderen van een label verwijdert het van alle documenten.',
+    'Weet u zeker dat u het label "{{ name }}" wilt verwijderen? Het verwijderen van een label verwijdert het van alle documenten.',
   'tags.delete.confirm.confirm-button': 'Verwijderen',
   'tags.delete.confirm.cancel-button': 'Annuleren',
   'tags.delete.success': 'Label succesvol verwijderd',

--- a/apps/papra-client/src/locales/pl.dictionary.ts
+++ b/apps/papra-client/src/locales/pl.dictionary.ts
@@ -736,7 +736,7 @@ export const translations: Partial<TranslationsDictionary> = {
   'tags.delete': 'Usuń tag',
   'tags.delete.confirm.title': 'Usuń tag',
   'tags.delete.confirm.message':
-    'Czy na pewno chcesz usunąć ten tag? Usunięcie tagu spowoduje jego usunięcie ze wszystkich dokumentów.',
+    'Czy na pewno chcesz usunąć tag „{{ name }}”? Usunięcie tagu spowoduje jego usunięcie ze wszystkich dokumentów.',
   'tags.delete.confirm.confirm-button': 'Usuń',
   'tags.delete.confirm.cancel-button': 'Anuluj',
   'tags.delete.success': 'Tag został pomyślnie usunięty',

--- a/apps/papra-client/src/locales/pt-BR.dictionary.ts
+++ b/apps/papra-client/src/locales/pt-BR.dictionary.ts
@@ -742,7 +742,7 @@ export const translations: Partial<TranslationsDictionary> = {
   'tags.delete': 'Excluir tag',
   'tags.delete.confirm.title': 'Excluir tag',
   'tags.delete.confirm.message':
-    'Tem certeza de que deseja excluir esta tag? A exclusão de uma tag a removerá de todos os documentos.',
+    'Tem certeza de que deseja excluir a tag "{{ name }}"? A exclusão de uma tag a removerá de todos os documentos.',
   'tags.delete.confirm.confirm-button': 'Excluir',
   'tags.delete.confirm.cancel-button': 'Cancelar',
   'tags.delete.success': 'Tag excluída com sucesso',

--- a/apps/papra-client/src/locales/pt.dictionary.ts
+++ b/apps/papra-client/src/locales/pt.dictionary.ts
@@ -753,7 +753,7 @@ export const translations: Partial<TranslationsDictionary> = {
   'tags.delete': 'Eliminar etiqueta',
   'tags.delete.confirm.title': 'Eliminar etiqueta',
   'tags.delete.confirm.message':
-    'Tem a certeza de que quer eliminar esta etiqueta? Eliminar uma etiqueta irá removê-la de todos os documentos.',
+    'Tem a certeza de que quer eliminar a etiqueta "{{ name }}"? Eliminar uma etiqueta irá removê-la de todos os documentos.',
   'tags.delete.confirm.confirm-button': 'Eliminar',
   'tags.delete.confirm.cancel-button': 'Cancelar',
   'tags.delete.success': 'Etiqueta eliminada com sucesso',

--- a/apps/papra-client/src/locales/ro.dictionary.ts
+++ b/apps/papra-client/src/locales/ro.dictionary.ts
@@ -745,7 +745,7 @@ export const translations: Partial<TranslationsDictionary> = {
   'tags.delete': 'Șterge eticheta',
   'tags.delete.confirm.title': 'Șterge eticheta',
   'tags.delete.confirm.message':
-    'Ești sigur că vrei să ștergi aceasta eticheta? Stergerea unei etichete o va elimina din toate documentele.',
+    'Ești sigur că vrei să ștergi eticheta „{{ name }}”? Stergerea unei etichete o va elimina din toate documentele.',
   'tags.delete.confirm.confirm-button': 'Șterge',
   'tags.delete.confirm.cancel-button': 'Anulează',
   'tags.delete.success': 'Eticheta a fost ștearsă cu succes',

--- a/apps/papra-client/src/locales/ru.dictionary.ts
+++ b/apps/papra-client/src/locales/ru.dictionary.ts
@@ -740,7 +740,7 @@ export const translations: Partial<TranslationsDictionary> = {
   'tags.delete': 'Удалить тег',
   'tags.delete.confirm.title': 'Удалить тег',
   'tags.delete.confirm.message':
-    'Вы уверены, что хотите удалить этот тег? Удаление тега уберёт его из всех документов.',
+    'Вы уверены, что хотите удалить тег «{{ name }}»? Удаление тега уберёт его из всех документов.',
   'tags.delete.confirm.confirm-button': 'Удалить',
   'tags.delete.confirm.cancel-button': 'Отмена',
   'tags.delete.success': 'Тег успешно удалён',

--- a/apps/papra-client/src/locales/sv.dictionary.ts
+++ b/apps/papra-client/src/locales/sv.dictionary.ts
@@ -735,7 +735,7 @@ export const translations: Partial<TranslationsDictionary> = {
   'tags.delete': 'Radera tagg',
   'tags.delete.confirm.title': 'Radera tagg',
   'tags.delete.confirm.message':
-    'Är du säker på att du vill ta bort den här taggen? Om du tar bort en tagg tas den bort från alla dokument.',
+    'Är du säker på att du vill ta bort taggen "{{ name }}"? Om du tar bort en tagg tas den bort från alla dokument.',
   'tags.delete.confirm.confirm-button': 'Radera',
   'tags.delete.confirm.cancel-button': 'Avbryt',
   'tags.delete.success': 'Tagg raderad',

--- a/apps/papra-client/src/locales/zh.dictionary.ts
+++ b/apps/papra-client/src/locales/zh.dictionary.ts
@@ -685,7 +685,7 @@ export const translations: Partial<TranslationsDictionary> = {
   'tags.update': '更新标签',
   'tags.delete': '删除标签',
   'tags.delete.confirm.title': '删除标签',
-  'tags.delete.confirm.message': '确定要删除此标签吗？删除后该标签将从所有文档中移除。',
+  'tags.delete.confirm.message': '确定要删除标签“{{ name }}”吗？删除后该标签将从所有文档中移除。',
   'tags.delete.confirm.confirm-button': '删除',
   'tags.delete.confirm.cancel-button': '取消',
   'tags.delete.success': '标签已删除',

--- a/apps/papra-client/src/modules/tags/pages/tags.page.tsx
+++ b/apps/papra-client/src/modules/tags/pages/tags.page.tsx
@@ -331,7 +331,7 @@ export const TagsPage: Component = () => {
   const del = async ({ tag }: { tag: TagType }) => {
     const confirmed = await confirm({
       title: t('tags.delete.confirm.title'),
-      message: t('tags.delete.confirm.message'),
+      message: t('tags.delete.confirm.message', { name: tag.name }),
       cancelButton: {
         text: t('tags.delete.confirm.cancel-button'),
         variant: 'secondary',


### PR DESCRIPTION
## Summary
- include the tag name in the delete confirmation message
- pass the selected tag name to the localized confirmation string

Fixes #1443

## Verification
- TypeScript typecheck passes
- i18n locale tests pass (32 tests)
- Tested locally in demo mode at http://localhost:3000