### PR TITLE
fix(papra-client): restore image and PDF previews

### DIFF
--- a/.changeset/bright-images-preview.md
+++ b/.changeset/bright-images-preview.md
@@ -1,0 +1,5 @@
+---
+'@papra/app': patch
+---
+
+Fix image and PDF previews when document files are served as opaque downloads.

--- a/apps/papra-client/src/modules/documents/components/document-preview.component.tsx
+++ b/apps/papra-client/src/modules/documents/components/document-preview.component.tsx
@@ -136,7 +136,19 @@ export const DocumentBlobPreview: Component<{ blob: Blob; mimeType: string }> = 
       URL.revokeObjectURL(prev);
     }
 
-    return getIsImage() || getIsPdf() ? URL.createObjectURL(props.blob) : undefined;
+    if (!getIsImage() && !getIsPdf()) {
+      return undefined;
+    }
+
+    // The file endpoint intentionally serves files as application/octet-stream
+    // attachments. Re-wrap previewable files with their trusted document MIME
+    // type so browsers can render images and PDFs from the object URL.
+    const previewBlob =
+      props.blob.type === props.mimeType
+        ? props.blob
+        : new Blob([props.blob], { type: props.mimeType });
+
+    return URL.createObjectURL(previewBlob);
   });
 
   onCleanup(() => {


### PR DESCRIPTION
Fixes #1444

## Problem

Image documents can have a correct stored MIME type such as `image/jpeg`, while the authenticated file endpoint intentionally returns the bytes as `application/octet-stream` with `Content-Disposition: attachment`.

The Papra client fetches that response as a `Blob` and passes it directly to `URL.createObjectURL()`. The blob therefore retains the opaque `application/octet-stream` type, so the browser downloads the file but does not render it in the document preview. OCR and document downloads continue to work.

## Fix

For supported image and PDF previews, re-wrap the fetched blob with the trusted document MIME type before creating the object URL. This preserves the server's secure opaque-download headers while allowing the client preview to render.

## Scope

This fixes the client preview path for server-backed image/PDF documents. The Android upload shortcut and server storage behavior do not need to change.

## Validation

- Oxlint passed for the changed component
- Oxfmt passed for the changed files
- `git diff --check` passed
- Production Vite build passed
- Reproduced against the local server-backed setup on `main`
