### PR TITLE
fix(db): refresh updatedAt on update

### DIFF
--- a/.changeset/dull-mice-shout.md
+++ b/.changeset/dull-mice-shout.md
@@ -1,0 +1,5 @@
+---
+'@papra/app': patch
+---
+
+Fixed missing refresh of the updatedAt db attribute.

--- a/apps/papra-server/src/migrations/list/0016-case-insensitive-tag-name-uniq-constraint.migration.test.ts
+++ b/apps/papra-server/src/migrations/list/0016-case-insensitive-tag-name-uniq-constraint.migration.test.ts
@@ -270,11 +270,10 @@ describe('0016-case-insensitive-tag-name-uniq-constraint migration', () => {
 
       const tags = await db.select().from(tagsTable).orderBy(tagsTable.id);
 
-      expect(tags).to.eql([
+      expect(tags.map(({ updatedAt: _, ...tag }) => tag)).to.eql([
         {
           id: 'tag_1',
           createdAt: new Date('2025-01-27'),
-          updatedAt: new Date('2025-01-27'),
           organizationId: 'org_1',
           name: 'Tag One',
           normalizedName: 'tag one',
@@ -284,7 +283,6 @@ describe('0016-case-insensitive-tag-name-uniq-constraint migration', () => {
         {
           id: 'tag_2',
           createdAt: new Date('2025-01-27'),
-          updatedAt: new Date('2025-01-27'),
           organizationId: 'org_1',
           name: 'Tag Two',
           normalizedName: 'tag two',
@@ -307,11 +305,11 @@ describe('0016-case-insensitive-tag-name-uniq-constraint migration', () => {
           ('doc1', 'org_1', 'Test Document', 'Test Document', 'text/plain', 'key1', 'hash1', 'This is a sample document content about testing.',0,0),
           ('doc2', 'org_1', 'Another Document', 'Another Document', 'text/plain', 'key2', 'hash2', 'This document discusses database migrations.',0,0)
         `),
-        db.run(sql`INSERT INTO tags (id, created_at, updated_at, organization_id, name, color, description) VALUES 
+        db.run(sql`INSERT INTO tags (id, created_at, updated_at, organization_id, name, color, description) VALUES
           ('tag_1', 1737936000000, 1737936000000, 'org_1', 'Tag One', '#ff0000', NULL),
           ('tag_2', 1737936000000, 1737936000000, 'org_1', 'Tag Two', '#00ff00', 'Tag two description')
         `),
-        db.run(sql`INSERT INTO documents_tags (document_id, tag_id) VALUES 
+        db.run(sql`INSERT INTO documents_tags (document_id, tag_id) VALUES
           ('doc1', 'tag_1'),
           ('doc1', 'tag_2'),
           ('doc2', 'tag_2')
@@ -353,7 +351,7 @@ describe('0016-case-insensitive-tag-name-uniq-constraint migration', () => {
         db.run(
           sql`INSERT INTO organizations(id, name, created_at, updated_at) VALUES ('org_1', 'Org 1', 1737936000000, 1737936000000)`,
         ),
-        db.run(sql`INSERT INTO tags (id, created_at, updated_at, organization_id, name, normalized_name, color, description) VALUES 
+        db.run(sql`INSERT INTO tags (id, created_at, updated_at, organization_id, name, normalized_name, color, description) VALUES
           ('tag_1', 1737936000000, 1737936000000, 'org_1', 'Tag One', NULL, '#ff0000', NULL),
           ('tag_2', 1737936000000, 1737936000000, 'org_1', 'Tag One', NULL, '#ff0000', NULL)
         `),
@@ -379,7 +377,7 @@ describe('0016-case-insensitive-tag-name-uniq-constraint migration', () => {
         const name = `Tag ${i}`;
         const id = `tag_${i.toString().padStart(4, '0')}`;
 
-        await db.run(sql`INSERT INTO tags (id, created_at, updated_at, organization_id, name, color, description) VALUES 
+        await db.run(sql`INSERT INTO tags (id, created_at, updated_at, organization_id, name, color, description) VALUES
           (${id}, 1737936000000, 1737936000000, 'org_1', ${name}, '#ff0000', NULL)
         `);
       }

--- a/apps/papra-server/src/modules/documents/documents.usecases.test.ts
+++ b/apps/papra-server/src/modules/documents/documents.usecases.test.ts
@@ -1220,40 +1220,42 @@ describe('documents usecases', () => {
         changes: { name: 'new-name.txt', content: 'Updated content' },
       });
 
-      expect(eventServices.getEmittedEvents()).to.eql([
-        {
-          eventName: 'document.updated',
-          payload: {
-            changes: {
-              content: 'Updated content',
-              name: 'new-name.txt',
-            },
-            document: {
-              content: 'Updated content',
-              createdAt: new Date('2025-12-10'),
-              createdBy: null,
-              deletedAt: null,
-              deletedBy: null,
-              fileEncryptionAlgorithm: null,
-              fileEncryptionKekVersion: null,
-              fileEncryptionKeyWrapped: null,
-              id: 'document-1',
-              isDeleted: false,
-              mimeType: 'text/plain',
-              notes: null,
-              name: 'new-name.txt',
-              documentDate: null,
-              organizationId: 'organization-1',
-              originalName: 'file-1.txt',
-              originalSha256Hash: 'hash',
-              originalSize: 0,
-              originalStorageKey: 'organization-1/originals/document-1.txt',
-              updatedAt: new Date('2025-12-11'),
-            },
-            userId: 'user-1',
+      const emittedEvents = eventServices.getEmittedEvents();
+
+      expect(emittedEvents.length).to.eql(1);
+      const event = emittedEvents[0];
+
+      expect(event).toMatchObject({
+        eventName: 'document.updated',
+        payload: {
+          changes: {
+            content: 'Updated content',
+            name: 'new-name.txt',
           },
+          document: {
+            content: 'Updated content',
+            createdAt: new Date('2025-12-10'),
+            createdBy: null,
+            deletedAt: null,
+            deletedBy: null,
+            fileEncryptionAlgorithm: null,
+            fileEncryptionKekVersion: null,
+            fileEncryptionKeyWrapped: null,
+            id: 'document-1',
+            isDeleted: false,
+            mimeType: 'text/plain',
+            notes: null,
+            name: 'new-name.txt',
+            documentDate: null,
+            organizationId: 'organization-1',
+            originalName: 'file-1.txt',
+            originalSha256Hash: 'hash',
+            originalSize: 0,
+            originalStorageKey: 'organization-1/originals/document-1.txt',
+          },
+          userId: 'user-1',
         },
-      ]);
+      });
     });
   });
 });

--- a/apps/papra-server/src/modules/organizations/organizations.repository.test.ts
+++ b/apps/papra-server/src/modules/organizations/organizations.repository.test.ts
@@ -57,27 +57,26 @@ describe('organizations repository', () => {
         .from(organizationInvitationsTable)
         .orderBy(organizationInvitationsTable.id);
 
-      expect(invitations).to.eql([
+      expect(
+        invitations.map(({ id, status, expiresAt, email }) => ({ id, status, expiresAt, email })),
+      ).to.deep.equal([
         {
           id: 'invitation_1',
           status: 'expired',
           expiresAt: new Date('2025-05-12'),
           email: 'test-1@test.com',
-          ...commonInvitation,
         },
         {
           id: 'invitation_2',
           status: 'pending',
           expiresAt: new Date('2025-05-14'),
           email: 'test-2@test.com',
-          ...commonInvitation,
         },
         {
           id: 'invitation_3',
           status: 'accepted',
           expiresAt: new Date('2025-05-05'),
           email: 'test-3@test.com',
-          ...commonInvitation,
         },
       ]);
     });

--- a/apps/papra-server/src/modules/shared/db/columns.helpers.ts
+++ b/apps/papra-server/src/modules/shared/db/columns.helpers.ts
@@ -22,7 +22,8 @@ export function createUpdatedAtField() {
   return {
     updatedAt: integer('updated_at', { mode: 'timestamp_ms' })
       .notNull()
-      .$default(() => new Date()),
+      .$default(() => new Date())
+      .$onUpdate(() => new Date()),
   };
 }
 


### PR DESCRIPTION
Hi there,

I noticed that when using the `createUpdatedAtField` it does not update the `updatedAt`. So I created this little PR that will make sure it does update the date when you, for example, edit the document title name.

Can you agree this is a needed fix?

Thanks!

PS: Not a native English speaker, so sorry that I used AI to write the commit message.